### PR TITLE
Fixed bug in translating browse paths to node IDs.

### DIFF
--- a/LibUA/Client.cs
+++ b/LibUA/Client.cs
@@ -2721,7 +2721,7 @@ namespace LibUA
 				succeeded &= sendBuf.Encode(reqHeader);
 
 				succeeded &= sendBuf.Encode((UInt32)requests.Length);
-				for (int i = 0; i < results.Length; i++)
+				for (int i = 0; i < requests.Length; i++)
 				{
 					succeeded &= sendBuf.Encode(requests[i]);
 				}


### PR DESCRIPTION
The for-loop should iterate over requests, not results which is null at that time.