### PR TITLE
Node creating/deleting by a client and few other changes

### DIFF
--- a/NET Core/LibUA/AddressSpace.cs
+++ b/NET Core/LibUA/AddressSpace.cs
@@ -182,9 +182,33 @@ namespace LibUA
 					return false;
 				}
 
-				return IdType == NodeIdNetType.Numeric ?
-					NumericIdentifier == other.NumericIdentifier :
-					StringIdentifier == other.StringIdentifier;
+				return IdType == NodeIdNetType.Numeric ? NumericIdentifier == other.NumericIdentifier
+					: IdType == NodeIdNetType.String ? StringIdentifier == other.StringIdentifier
+					: EqualByteString(ByteStringIdentifier, other.ByteStringIdentifier);
+			}
+
+			private bool EqualByteString(byte[] a, byte[] b)
+			{
+				if (a == null && b == null)
+				{
+					return true;
+				}
+				if (a == null || b == null)
+				{
+					return false;
+				}
+				if (a.Length.Equals(b.Length))
+				{
+					for (int i = 0; i < a.Length; i++)
+					{
+						if (!byte.Equals(a[i], b[i]))
+						{
+							return false;
+						}
+					}
+					return true;
+				}
+				return false;
 			}
 
 			public override bool Equals(object other)

--- a/NET Core/LibUA/Client.cs
+++ b/NET Core/LibUA/Client.cs
@@ -26,6 +26,8 @@ namespace LibUA
 
 		public readonly string Target;
 		public readonly int Port;
+		public readonly string Path;
+
 		public readonly int Timeout;
 
 		protected SLChannel config = null;
@@ -86,9 +88,16 @@ namespace LibUA
 		}
 
 		public Client(string Target, int Port, int Timeout, int MaximumMessageSize = 1 << 18)
+			: this(Target, Port, null, Timeout, MaximumMessageSize)
+		{
+
+		}
+
+		public Client(string Target, int Port, string Path, int Timeout, int MaximumMessageSize = 1 << 18)
 		{
 			this.Target = Target;
 			this.Port = Port;
+			this.Path = Path;
 			this.Timeout = Timeout;
 			this.MaximumMessageSize = MaximumMessageSize;
 		}
@@ -517,7 +526,7 @@ namespace LibUA
 				succeeded &= sendBuf.Encode(new NodeId(RequestCode.GetEndpointsRequest));
 				succeeded &= sendBuf.Encode(reqHeader);
 
-				succeeded &= sendBuf.EncodeUAString(string.Format("opc.tcp://{0}:{1}", config.Endpoint.Address.ToString(), config.Endpoint.Port.ToString()));
+				succeeded &= sendBuf.EncodeUAString(GetEndpointString());
 				// LocaleIds
 				succeeded &= sendBuf.EncodeUAString(localeIDs);
 				// ProfileUris
@@ -617,7 +626,7 @@ namespace LibUA
 				succeeded &= sendBuf.Encode(new NodeId(RequestCode.FindServersRequest));
 				succeeded &= sendBuf.Encode(reqHeader);
 
-				succeeded &= sendBuf.EncodeUAString(string.Format("opc.tcp://{0}:{1}", config.Endpoint.Address.ToString(), config.Endpoint.Port.ToString()));
+				succeeded &= sendBuf.EncodeUAString(GetEndpointString());
 				// LocaleIds
 				succeeded &= sendBuf.EncodeUAString(localeIDs);
 				// ProfileIds
@@ -863,7 +872,7 @@ namespace LibUA
 			succeeded &= sendBuf.Encode(config.TL.LocalConfig.SendBufferSize);
 			succeeded &= sendBuf.Encode(config.TL.LocalConfig.MaxMessageSize);
 			succeeded &= sendBuf.Encode(config.TL.LocalConfig.MaxChunkCount);
-			succeeded &= sendBuf.EncodeUAString(string.Format("opc.tcp://{0}:{1}", config.Endpoint.Address.ToString(), config.Endpoint.Port.ToString()));
+			succeeded &= sendBuf.EncodeUAString(GetEndpointString());
 
 			if (!succeeded)
 			{
@@ -935,6 +944,21 @@ namespace LibUA
 			//}
 
 			return StatusCode.Good;
+		}
+
+		private string GetEndpointString()
+		{
+			string endpointString;
+			if (string.IsNullOrWhiteSpace(Path))
+			{
+				endpointString = string.Format("opc.tcp://{0}:{1}", Target, config.Endpoint.Port.ToString());
+			}
+			else
+			{
+				endpointString = string.Format("opc.tcp://{0}:{1}/{2}", Target, config.Endpoint.Port.ToString(), Path);
+			}
+
+			return endpointString;
 		}
 
 		protected void MarkPositionAsSize(MemoryBuffer mb, UInt32 position)
@@ -1779,7 +1803,7 @@ namespace LibUA
 				succeeded &= sendBuf.Encode(appDesc);
 				// ServerUri
 				succeeded &= sendBuf.EncodeUAString((string)null);
-				succeeded &= sendBuf.EncodeUAString(string.Format("opc.tcp://{0}:{1}", config.Endpoint.Address.ToString(), config.Endpoint.Port.ToString()));
+				succeeded &= sendBuf.EncodeUAString(GetEndpointString());
 				succeeded &= sendBuf.EncodeUAString(sessionName);
 				succeeded &= sendBuf.EncodeUAByteString(config.LocalNonce);
 				if (ApplicationCertificate == null)

--- a/NET Core/LibUA/Client.cs
+++ b/NET Core/LibUA/Client.cs
@@ -2215,6 +2215,7 @@ namespace LibUA
 					succeeded &= recvHandler.RecvBuf.DecodeUAByteString(out contPoint);
 					succeeded &= recvHandler.RecvBuf.Decode(out numRefDesc);
 
+					if (numRefDesc == uint.MaxValue) { numRefDesc = 0; }
 					refDescs = new ReferenceDescription[numRefDesc];
 					for (int j = 0; j < refDescs.Length; j++)
 					{
@@ -2938,6 +2939,10 @@ namespace LibUA
 					succeeded &= recvHandler.RecvBuf.Decode(out status);
 
 					succeeded &= recvHandler.RecvBuf.Decode(out numResults);
+					if (numResults == uint.MaxValue)
+					{
+						numResults = 0;
+					}
 					resultStatus = new UInt32[numResults];
 					for (int j = 0; j < numResults; j++)
 					{
@@ -2945,14 +2950,18 @@ namespace LibUA
 					}
 
 					succeeded &= recvHandler.RecvBuf.Decode(out numDiagnosticInfos);
-					if (numDiagnosticInfos > 0)
+					if (numDiagnosticInfos > 0 && numDiagnosticInfos != uint.MaxValue)
 					{
 						return StatusCode.BadTypeMismatch;
 					}
 
 					succeeded &= recvHandler.RecvBuf.Decode(out numOutputs);
+					if (numOutputs == uint.MaxValue)
+					{
+						numOutputs = 0;
+					}
 					outputs = new object[numOutputs];
-					for (int j = 0; j < numResults; j++)
+					for (int j = 0; j < numOutputs; j++)
 					{
 						succeeded &= recvHandler.RecvBuf.VariantDecode(out outputs[j]);
 					}

--- a/NET Core/LibUA/MemoryBufferExtensions.cs
+++ b/NET Core/LibUA/MemoryBufferExtensions.cs
@@ -98,6 +98,397 @@ namespace LibUA
 
 			return true;
 		}
+		public static bool Encode(this MemoryBuffer mem, ObjectAttributes item)
+		{
+			if (!mem.Encode((uint)item.SpecifiedAttributes)) { return false; }
+			if (!mem.Encode(item.DisplayName)) { return false; }
+			if (!mem.Encode(item.Description)) { return false; }
+			if (!mem.Encode(item.WriteMask)) { return false; }
+			if (!mem.Encode(item.UserWriteMask)) { return false; }
+			if (!mem.Encode(item.EventNotifier)) { return false; }
+
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out ObjectAttributes item)
+		{
+			item = null;
+
+			uint specifiedAttributes;
+			LocalizedText displayName;
+			LocalizedText description;
+			uint writeMask;
+			uint userWriteMask;
+			byte eventNotifier;
+
+			if (!mem.Decode(out specifiedAttributes)) { return false; }
+			if (!mem.Decode(out displayName)) { return false; }
+			if (!mem.Decode(out description)) { return false; }
+			if (!mem.Decode(out writeMask)) { return false; }
+			if (!mem.Decode(out userWriteMask)) { return false; }
+			if (!mem.Decode(out eventNotifier)) { return false; }
+			try
+			{
+				item = new ObjectAttributes()
+				{
+					SpecifiedAttributes = (NodeAttributesMask)specifiedAttributes,
+					DisplayName = displayName,
+					Description = description,
+					WriteMask = writeMask,
+					UserWriteMask = userWriteMask,
+					EventNotifier = eventNotifier,
+				};
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, ObjectTypeAttributes item)
+		{
+			if (!mem.Encode((uint)item.SpecifiedAttributes)) { return false; }
+			if (!mem.Encode(item.DisplayName)) { return false; }
+			if (!mem.Encode(item.Description)) { return false; }
+			if (!mem.Encode(item.WriteMask)) { return false; }
+			if (!mem.Encode(item.UserWriteMask)) { return false; }
+			if (!mem.Encode(item.IsAbstract)) { return false; }
+
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out ObjectTypeAttributes item)
+		{
+			item = null;
+
+			uint specifiedAttributes;
+			LocalizedText displayName;
+			LocalizedText description;
+			uint writeMask;
+			uint userWriteMask;
+			bool isAbstract;
+
+			if (!mem.Decode(out specifiedAttributes)) { return false; }
+			if (!mem.Decode(out displayName)) { return false; }
+			if (!mem.Decode(out description)) { return false; }
+			if (!mem.Decode(out writeMask)) { return false; }
+			if (!mem.Decode(out userWriteMask)) { return false; }
+			if (!mem.Decode(out isAbstract)) { return false; }
+			try
+			{
+				item = new ObjectTypeAttributes()
+				{
+					SpecifiedAttributes = (NodeAttributesMask)specifiedAttributes,
+					DisplayName = displayName,
+					Description = description,
+					WriteMask = writeMask,
+					UserWriteMask = userWriteMask,
+					IsAbstract = isAbstract,
+				};
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, VariableAttributes item)
+		{
+			if (!mem.Encode((uint)item.SpecifiedAttributes)) { return false; }
+			if (!mem.Encode(item.DisplayName)) { return false; }
+			if (!mem.Encode(item.Description)) { return false; }
+			if (!mem.Encode(item.WriteMask)) { return false; }
+			if (!mem.Encode(item.UserWriteMask)) { return false; }
+			if (!mem.VariantEncode(item.Value)) { return false; }
+			if (!mem.Encode(item.DataType)) { return false; }
+			if (!mem.Encode(item.ValueRank)) { return false; }
+			if (!mem.Encode(item.ArrayDimensions.Length)) { return false; }
+			for (int i = 0; i < item.ArrayDimensions.Length; i++)
+			{
+				if (!mem.Encode(item.ArrayDimensions[i])) { return false; }
+			}
+			if (!mem.Encode(item.AccessLevel)) { return false; }
+			if (!mem.Encode(item.UserAccessLevel)) { return false; }
+			if (!mem.Encode(item.MinimumSamplingInterval)) { return false; }
+			if (!mem.Encode(item.Historizing)) { return false; }
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out VariableAttributes item)
+		{
+			item = null;
+
+			uint attributesUint;
+			LocalizedText DisplayName = new LocalizedText("");
+			LocalizedText Description = new LocalizedText("");
+			uint WriteMask = 0;
+			uint UserWriteMask = 0;
+			object Value = null;
+			NodeId DataType = new NodeId(0U);
+			int ValueRank = 0;
+			uint[] ArrayDimensions = null;
+			byte AccessLevel = 0;
+			byte UserAccessLevel = 0;
+			double MinimumSamplingInterval = 0;
+			bool Historizing = false;
+
+			if (!mem.Decode(out attributesUint)) { return false; }
+			if (!mem.Decode(out DisplayName)) { return false; }
+			if (!mem.Decode(out Description)) { return false; }
+			if (!mem.Decode(out WriteMask)) { return false; }
+			if (!mem.Decode(out UserWriteMask)) { return false; }
+			if (!mem.VariantDecode(out Value)) { return false; }
+			if (!mem.Decode(out DataType)) { return false; }
+			if (!mem.Decode(out ValueRank)) { return false; }
+			uint arrayLength;
+
+			if (!mem.Decode(out arrayLength)) { return false; }
+			if (arrayLength == uint.MaxValue)
+			{
+				ArrayDimensions = null;
+			}
+			else
+			{
+				ArrayDimensions = new uint[arrayLength];
+
+				for (int i = 0; i < arrayLength; i++)
+				{
+					if (!mem.Decode(out ArrayDimensions[i])) { return false; }
+				}
+			}
+			if (!mem.Decode(out AccessLevel)) { return false; }
+			if (!mem.Decode(out UserAccessLevel)) { return false; }
+			if (!mem.Decode(out MinimumSamplingInterval)) { return false; }
+			if (!mem.Decode(out Historizing)) { return false; }
+
+			try
+			{
+				item = new VariableAttributes()
+				{
+					SpecifiedAttributes = (NodeAttributesMask)attributesUint,
+					DisplayName = DisplayName,
+					Description = Description,
+					WriteMask = WriteMask,
+					UserWriteMask = UserWriteMask,
+					Value = Value,
+					DataType = DataType,
+					ValueRank = ValueRank,
+					ArrayDimensions = ArrayDimensions,
+					AccessLevel = AccessLevel,
+					UserAccessLevel = UserAccessLevel,
+					MinimumSamplingInterval = MinimumSamplingInterval,
+					Historizing = Historizing,
+				};
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, VariableTypeAttributes item)
+		{
+			if (!mem.Encode((uint)item.SpecifiedAttributes)) { return false; }
+			if (!mem.Encode(item.DisplayName)) { return false; }
+			if (!mem.Encode(item.Description)) { return false; }
+			if (!mem.Encode(item.WriteMask)) { return false; }
+			if (!mem.Encode(item.UserWriteMask)) { return false; }
+			if (!mem.VariantEncode(item.Value)) { return false; }
+			if (!mem.Encode(item.DataType)) { return false; }
+			if (!mem.Encode(item.ValueRank)) { return false; }
+			if (!mem.Encode(item.ArrayDimensions.Length)) { return false; }
+			for (int i = 0; i < item.ArrayDimensions.Length; i++)
+			{
+				if (!mem.Encode(item.ArrayDimensions[i])) { return false; }
+			}
+			if (!mem.Encode(item.IsAbstract)) { return false; }
+
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out VariableTypeAttributes item)
+		{
+			item = null;
+
+			uint attributesUint;
+			LocalizedText DisplayName = new LocalizedText("");
+			LocalizedText Description = new LocalizedText("");
+			uint WriteMask = 0;
+			uint UserWriteMask = 0;
+			object Value = null;
+			NodeId DataType = new NodeId(0U);
+			int ValueRank = 0;
+			uint[] ArrayDimensions = null;
+			bool isAbstract = false;
+
+			if (!mem.Decode(out attributesUint)) { return false; }
+			if (!mem.Decode(out DisplayName)) { return false; }
+			if (!mem.Decode(out Description)) { return false; }
+			if (!mem.Decode(out WriteMask)) { return false; }
+			if (!mem.Decode(out UserWriteMask)) { return false; }
+			if (!mem.VariantDecode(out Value)) { return false; }
+			if (!mem.Decode(out DataType)) { return false; }
+			if (!mem.Decode(out ValueRank)) { return false; }
+			uint arrayLength;
+
+			if (!mem.Decode(out arrayLength)) { return false; }
+			if (arrayLength == uint.MaxValue)
+			{
+				ArrayDimensions = null;
+			}
+			else
+			{
+				ArrayDimensions = new uint[arrayLength];
+
+				for (int i = 0; i < arrayLength; i++)
+				{
+					if (!mem.Decode(out ArrayDimensions[i])) { return false; }
+				}
+			}
+			if (!mem.Decode(out isAbstract)) { return false; }
+
+			try
+			{
+				item = new VariableTypeAttributes()
+				{
+					SpecifiedAttributes = (NodeAttributesMask)attributesUint,
+					DisplayName = DisplayName,
+					Description = Description,
+					WriteMask = WriteMask,
+					UserWriteMask = UserWriteMask,
+					Value = Value,
+					DataType = DataType,
+					ValueRank = ValueRank,
+					ArrayDimensions = ArrayDimensions,
+					IsAbstract = isAbstract,
+				};
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, AddNodesItem item)
+		{
+			if (!mem.Encode(item.ParentNodeId)) { return false; }
+			if (!mem.Encode(item.ReferenceTypeId)) { return false; }
+			if (!mem.Encode(item.RequestedNewNodeId)) { return false; }
+			if (!mem.Encode(item.BrowseName)) { return false; }
+			if (!mem.Encode((uint)item.NodeClass)) { return false; }
+			if (!mem.Encode(item.NodeAttributes)) { return false; }
+			if (!mem.Encode(item.TypeDefinition)) { return false; }
+
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out AddNodesItem item)
+		{
+			item = null;
+
+			NodeId ParentNodeId;
+			NodeId ReferenceTypeId;
+			NodeId RequestedNewNodeId;
+			QualifiedName BrowseName;
+			uint nodeClass;
+			ExtensionObject NodeAttributes;
+			NodeId TypeDefinition;
+
+			if (!mem.Decode(out ParentNodeId)) { return false; }
+			if (!mem.Decode(out ReferenceTypeId)) { return false; }
+			if (!mem.Decode(out RequestedNewNodeId)) { return false; }
+			if (!mem.Decode(out BrowseName)) { return false; }
+			if (!mem.Decode(out nodeClass)) { return false; }
+			if (!mem.Decode(out NodeAttributes)) { return false; }
+			if (!mem.Decode(out TypeDefinition)) { return false; }
+			try
+			{
+				item = new AddNodesItem()
+				{
+					ParentNodeId = ParentNodeId,
+					ReferenceTypeId = ReferenceTypeId,
+					RequestedNewNodeId = RequestedNewNodeId,
+					BrowseName = BrowseName,
+					NodeClass = (NodeClass)nodeClass,
+					NodeAttributes = NodeAttributes,
+					TypeDefinition = TypeDefinition
+				};
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, AddNodesResult res)
+		{
+			if (!mem.Encode((uint)res.StatusCode)) { return false; }
+			if (!mem.Encode(res.AddedNodeId)) { return false; }
+
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out AddNodesResult res)
+		{
+			res = null;
+
+			uint statusCode;
+			NodeId addedNodeId;
+
+			if (!mem.Decode(out statusCode)) { return false; }
+			if (!mem.Decode(out addedNodeId)) { return false; }
+
+			try
+			{
+				res = new AddNodesResult((StatusCode)statusCode, addedNodeId);
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, DeleteNodesItem item)
+		{
+			if (!mem.Encode(item.NodeId)) { return false; }
+			if (!mem.Encode(item.DeleteTargetReferences)) { return false; }
+
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out DeleteNodesItem item)
+		{
+			item = null;
+
+			NodeId nodeId;
+			bool deleteTargetReferences;
+
+			if (!mem.Decode(out nodeId)) { return false; }
+			if (!mem.Decode(out deleteTargetReferences)) { return false; }
+
+			try
+			{
+				item = new DeleteNodesItem(nodeId, deleteTargetReferences);
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
 
 		public static bool Encode(this MemoryBuffer mem, MonitoredItemModifyRequest rq)
 		{
@@ -1208,6 +1599,34 @@ namespace LibUA
 				if (!mem.DecodeUAByteString(out str)) { return false; }
 				obj.Body = str;
 
+				var tmp = new MemoryBuffer(str);
+
+				switch (obj.TypeId.NumericIdentifier)
+				{
+					case (uint)UAConst.ObjectAttributes_Encoding_DefaultBinary:
+						ObjectAttributes oa;
+						if (!tmp.Decode(out oa)) { return false; }
+						obj.Payload = oa;
+						break;
+					case (uint)UAConst.ObjectTypeAttributes_Encoding_DefaultBinary:
+						ObjectTypeAttributes ota;
+						if (!tmp.Decode(out ota)) { return false; }
+						obj.Payload = ota;
+						break;
+					case (uint)UAConst.VariableAttributes_Encoding_DefaultBinary:
+						VariableAttributes va;
+						if (!tmp.Decode(out va)) { return false; }
+						obj.Payload = va;
+						break;
+					case (uint)UAConst.VariableTypeAttributes_Encoding_DefaultBinary:
+						VariableTypeAttributes vta;
+						if (!tmp.Decode(out vta)) { return false; }
+						obj.Payload = vta;
+						break;
+					default:
+						break;
+				}
+
 				return true;
 			}
 
@@ -1220,6 +1639,39 @@ namespace LibUA
 			{
 				if (!mem.Encode(NodeId.Zero)) { return false; }
 				return mem.Encode((byte)ExtensionObjectBodyType.None);
+			}
+
+			if (obj.Payload != null)
+			{
+				var tmp = new MemoryBuffer(mem.Capacity);
+				UAConst payloadType = 0;
+				switch (obj.Payload)
+				{
+					case ObjectAttributes oa:
+						payloadType = UAConst.ObjectAttributes_Encoding_DefaultBinary;
+						if (!tmp.Encode(oa)) { return false; }
+						break;
+					case ObjectTypeAttributes ota:
+						payloadType = UAConst.ObjectTypeAttributes_Encoding_DefaultBinary;
+						if (!tmp.Encode(ota)) { return false; }
+						break;
+					case VariableAttributes va:
+						payloadType = UAConst.VariableAttributes_Encoding_DefaultBinary;
+						if (!tmp.Encode(va)) { return false; }
+						break;
+					case VariableTypeAttributes vta:
+						payloadType = UAConst.VariableTypeAttributes_Encoding_DefaultBinary;
+						if (!tmp.Encode(vta)) { return false; }
+						break;
+					default:
+						break;
+				}
+				if (payloadType != 0)
+				{
+					obj.TypeId = new NodeId(payloadType);
+					obj.Body = new byte[tmp.Position];
+					Array.Copy(tmp.Buffer, obj.Body, obj.Body.Length);
+				}
 			}
 
 			if (!mem.Encode(obj.TypeId)) { return false; }

--- a/NET Core/LibUA/MemoryBufferExtensions.cs
+++ b/NET Core/LibUA/MemoryBufferExtensions.cs
@@ -490,6 +490,100 @@ namespace LibUA
 			return true;
 		}
 
+		public static bool Encode(this MemoryBuffer mem, AddReferencesItem item)
+		{
+			if (!mem.Encode(item.SourceNodeId)) { return false; }
+			if (!mem.Encode(item.ReferenceTypeId)) { return false; }
+			if (!mem.Encode(item.IsForward)) { return false; }
+			if (!mem.EncodeUAString(item.TargetServerUri)) { return false; }
+			if (!mem.Encode(item.TargetNodeId)) { return false; }
+			if (!mem.Encode((uint)item.TargetNodeClass)) { return false; }
+
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out AddReferencesItem item)
+		{
+			item = null;
+
+			NodeId SourceNodeId;
+			NodeId ReferenceTypeId;
+			Boolean IsForward;
+			String TargetServerUri;
+			NodeId TargetNodeId;
+			uint TargetNodeClass;
+
+			if (!mem.Decode(out SourceNodeId)) { return false; }
+			if (!mem.Decode(out ReferenceTypeId)) { return false; }
+			if (!mem.Decode(out IsForward)) { return false; }
+			if (!mem.DecodeUAString(out TargetServerUri)) { return false; }
+			if (!mem.Decode(out TargetNodeId)) { return false; }
+			if (!mem.Decode(out TargetNodeClass)) { return false; }
+			try
+			{
+				item = new AddReferencesItem()
+				{
+					SourceNodeId = SourceNodeId,
+					ReferenceTypeId = ReferenceTypeId,
+					IsForward = IsForward,
+					TargetServerUri = TargetServerUri,
+					TargetNodeId = TargetNodeId,
+					TargetNodeClass = (NodeClass)TargetNodeClass,
+				};
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, DeleteReferencesItem item)
+		{
+			if (!mem.Encode(item.SourceNodeId)) { return false; }
+			if (!mem.Encode(item.ReferenceTypeId)) { return false; }
+			if (!mem.Encode(item.IsForward)) { return false; }
+			if (!mem.Encode(item.TargetNodeId)) { return false; }
+			if (!mem.Encode(item.DeleteBidirectional)) { return false; }
+
+			return true;
+		}
+
+		public static bool Decode(this MemoryBuffer mem, out DeleteReferencesItem item)
+		{
+			item = null;
+
+			NodeId SourceNodeId;
+			NodeId ReferenceTypeId;
+			Boolean IsForward;
+			NodeId TargetNodeId;
+			bool DeleteBidirectional;
+
+			if (!mem.Decode(out SourceNodeId)) { return false; }
+			if (!mem.Decode(out ReferenceTypeId)) { return false; }
+			if (!mem.Decode(out IsForward)) { return false; }
+			if (!mem.Decode(out TargetNodeId)) { return false; }
+			if (!mem.Decode(out DeleteBidirectional)) { return false; }
+			try
+			{
+				item = new DeleteReferencesItem()
+				{
+					SourceNodeId = SourceNodeId,
+					ReferenceTypeId = ReferenceTypeId,
+					IsForward = IsForward,
+					TargetNodeId = TargetNodeId,
+					DeleteBidirectional = DeleteBidirectional,
+				};
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
 		public static bool Encode(this MemoryBuffer mem, MonitoredItemModifyRequest rq)
 		{
 			if (!mem.Encode(rq.MonitoredItemId)) { return false; }

--- a/NET Core/LibUA/MemoryBufferExtensions.cs
+++ b/NET Core/LibUA/MemoryBufferExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using LibUA.Core;
@@ -1561,7 +1562,7 @@ namespace LibUA
 				return mem.Encode((UInt32)0xFFFFFFFFu);
 			}
 
-			byte[] bytes = Encoding.ASCII.GetBytes(str);
+			byte[] bytes = Encoding.UTF8.GetBytes(str);
 			if (!mem.Encode((uint)bytes.Length))
 			{
 				return false;
@@ -1602,7 +1603,7 @@ namespace LibUA
 			Array.Copy(mem.Buffer, mem.Position, arr, 0, Length);
 			mem.Position += (int)Length;
 
-			str = Encoding.ASCII.GetString(arr);
+			str = Encoding.UTF8.GetString(arr);
 			return true;
 		}
 	}

--- a/NET Core/LibUA/Security.cs
+++ b/NET Core/LibUA/Security.cs
@@ -606,7 +606,7 @@ namespace LibUA
 			}
 		}
 
-		public static int GetPlainBlockSize(X509Certificate2 cert,  RSAEncryptionPadding useOaep)
+		public static int GetPlainBlockSize(X509Certificate2 cert, RSAEncryptionPadding useOaep)
 		{
 			var rsa = cert.PublicKey.Key as RSA;
 			if (rsa == null)
@@ -867,6 +867,10 @@ namespace LibUA
 					return StatusCode.BadSecurityChecksFailed;
 				}
 			}
+			else
+			{
+				decrSize = (int)messageSize;
+			}
 
 			if (securityMode >= MessageSecurityMode.Sign)
 			{
@@ -891,7 +895,7 @@ namespace LibUA
 						}
 					}
 
-					byte padValue = (byte)(recvBuf.Buffer[messageSize - sigSize - 1] + 1);
+					byte padValue = securityMode == MessageSecurityMode.SignAndEncrypt ? (byte)(recvBuf.Buffer[messageSize - sigSize - 1] + 1) : (byte)0;
 					if (decrSize > 0)
 					{
 						decrSize -= sigSize;

--- a/NET Core/LibUA/Types.cs
+++ b/NET Core/LibUA/Types.cs
@@ -7034,5 +7034,33 @@ namespace LibUA
 				DeleteTargetReferences = deleteTargetReferences;
 			}
 		}
+
+		public class AddReferencesItem
+		{
+			public NodeId SourceNodeId { get; set; }
+
+			public NodeId ReferenceTypeId { get; set; }
+
+			public Boolean IsForward { get; set; }
+
+			public String TargetServerUri { get; set; }
+
+			public NodeId TargetNodeId { get; set; }
+
+			public NodeClass TargetNodeClass { get; set; }
+		}
+
+		public class DeleteReferencesItem
+		{
+			public NodeId SourceNodeId { get; set; }
+
+			public NodeId ReferenceTypeId { get; set; }
+
+			public Boolean IsForward { get; set; }
+
+			public NodeId TargetNodeId { get; set; }
+
+			public Boolean DeleteBidirectional { get; set; }
+		}
 	}
 }

--- a/NET Core/LibUA/Types.cs
+++ b/NET Core/LibUA/Types.cs
@@ -5795,6 +5795,8 @@ namespace LibUA
 		{
 			public NodeId TypeId { get; set; }
 			public byte[] Body { get; set; }
+
+			public object Payload { get; set; }
 		}
 
 		public class DataValue
@@ -6872,6 +6874,165 @@ namespace LibUA
 
 			public Keyset[] LocalKeysets { get; set; }
 			public Keyset[] RemoteKeysets { get; set; }
+		}
+
+		public class AddNodesItem
+		{
+			public NodeId ParentNodeId { get; set; }
+			public NodeId ReferenceTypeId { get; set; }
+			public NodeId RequestedNewNodeId { get; set; }
+			public QualifiedName BrowseName { get; set; }
+			public NodeClass NodeClass { get; set; }
+			public ExtensionObject NodeAttributes { get; set; }
+			public NodeId TypeDefinition { get; set; }
+		}
+
+		public class AddNodesResult
+		{
+			public StatusCode StatusCode { get; }
+
+			public NodeId AddedNodeId { get; }
+
+			public AddNodesResult(StatusCode statusCode, NodeId addedNodeId)
+			{
+				StatusCode = statusCode;
+				AddedNodeId = addedNodeId;
+			}
+		}
+
+		public class ObjectAttributes
+		{
+			public NodeAttributesMask SpecifiedAttributes { get; set; }
+			public LocalizedText DisplayName { get; set; }
+			public LocalizedText Description { get; set; }
+			public uint WriteMask { get; set; }
+			public uint UserWriteMask { get; set; }
+			public byte EventNotifier { get; set; }
+
+			public ObjectAttributes()
+			{
+				SpecifiedAttributes = NodeAttributesMask.DisplayName
+											| NodeAttributesMask.Description
+											| NodeAttributesMask.WriteMask
+											| NodeAttributesMask.UserWriteMask
+											| NodeAttributesMask.EventNotifier;
+			}
+		}
+
+		public class ObjectTypeAttributes
+		{
+			public NodeAttributesMask SpecifiedAttributes { get; set; }
+			public LocalizedText DisplayName { get; set; }
+			public LocalizedText Description { get; set; }
+			public uint WriteMask { get; set; }
+			public uint UserWriteMask { get; set; }
+			public bool IsAbstract { get; set; }
+
+			public ObjectTypeAttributes()
+			{
+				SpecifiedAttributes = NodeAttributesMask.DisplayName
+											| NodeAttributesMask.Description
+											| NodeAttributesMask.WriteMask
+											| NodeAttributesMask.UserWriteMask
+											| NodeAttributesMask.IsAbstract;
+			}
+		}
+
+		public class VariableAttributes
+		{
+			public NodeAttributesMask SpecifiedAttributes { get; set; }
+			public LocalizedText DisplayName { get; set; }
+			public LocalizedText Description { get; set; }
+			public uint WriteMask { get; set; }
+			public uint UserWriteMask { get; set; }
+			public object Value { get; set; }
+			public NodeId DataType { get; set; }
+			public int ValueRank { get; set; }
+			public uint[] ArrayDimensions { get; set; }
+			public byte AccessLevel { get; set; }
+			public byte UserAccessLevel { get; set; }
+			public double MinimumSamplingInterval { get; set; }
+			public bool Historizing { get; set; }
+
+			public VariableAttributes()
+			{
+				SpecifiedAttributes = NodeAttributesMask.DisplayName
+					| NodeAttributesMask.Description
+					| NodeAttributesMask.WriteMask
+					| NodeAttributesMask.UserWriteMask
+					| NodeAttributesMask.Value
+					| NodeAttributesMask.DataType
+					| NodeAttributesMask.ValueRank
+					| NodeAttributesMask.ArrayDimensions
+					| NodeAttributesMask.AccessLevel
+					| NodeAttributesMask.UserAccessLevel
+					| NodeAttributesMask.MinimumSamplingInterval
+					| NodeAttributesMask.Historizing;
+
+				Description = new LocalizedText("");
+				DisplayName = new LocalizedText("");
+				WriteMask = 0;
+				UserWriteMask = 0;
+				Value = 0;
+				DataType = new NodeId(0, 0);
+				ValueRank = 0;
+				ArrayDimensions = new uint[0];
+				AccessLevel = 0;
+				UserAccessLevel = 0;
+				MinimumSamplingInterval = 0;
+				Historizing = false;
+			}
+		}
+
+		public class VariableTypeAttributes
+		{
+			public NodeAttributesMask SpecifiedAttributes { get; set; }
+			public LocalizedText DisplayName { get; set; }
+			public LocalizedText Description { get; set; }
+			public uint WriteMask { get; set; }
+			public uint UserWriteMask { get; set; }
+			public object Value { get; set; }
+			public NodeId DataType { get; set; }
+			public int ValueRank { get; set; }
+			public uint[] ArrayDimensions { get; set; }
+			public bool IsAbstract { get; set; }
+
+			public VariableTypeAttributes()
+			{
+				// 2112
+				SpecifiedAttributes = NodeAttributesMask.DisplayName
+					| NodeAttributesMask.Description
+					| NodeAttributesMask.WriteMask
+					| NodeAttributesMask.UserWriteMask
+					| NodeAttributesMask.Value
+					| NodeAttributesMask.DataType
+					| NodeAttributesMask.ValueRank
+					| NodeAttributesMask.ArrayDimensions
+					| NodeAttributesMask.IsAbstract;
+
+				Description = new LocalizedText("");
+				DisplayName = new LocalizedText("");
+				WriteMask = 0;
+				UserWriteMask = 0;
+				Value = 0;
+				DataType = new NodeId(0, 0);
+				ValueRank = 0;
+				ArrayDimensions = new uint[0];
+				IsAbstract = false;
+			}
+
+		}
+
+		public class DeleteNodesItem
+		{
+			public NodeId NodeId { get; }
+			public Boolean DeleteTargetReferences { get; }
+
+			public DeleteNodesItem(NodeId nodeId, bool deleteTargetReferences)
+			{
+				NodeId = nodeId;
+				DeleteTargetReferences = deleteTargetReferences;
+			}
 		}
 	}
 }


### PR DESCRIPTION
I've been using the LibUA for developing a client to work with a third-party UA-server.
According to that I had to made changes in the library.

All changes have been made for a client application and haven't been tested for a server.
Though I've written `Encode/Decode` methods for all new classes, I've never tested server side encoding and decoding.

All changes was made for the `Net Core/LibUA`. Are they should be backported to the `Net`?

Changes:
- Added methods `CloseSession` и `CloseSecureChannel` for correct disconnecting.
- Added methods for UA Nodes creating/deleting:
  - `AddNodes` (and required classes `AddNodesItem`, `AddNodesResult`)
  - `DeleteNodes` (`DeleteNodesItem`)
  - `AddRefernces` (`AddReferncesItem`)
  - `DeleteReferences` (`DeleteReferencesItem`)
- `ExtensionObject` extended with a property `Payload` and created classes required for the `AddNodesItem`:
  - `ObjectAttributes`
  - `ObjectTypeAttributes`
  - `VariableAttributes`
  - `VariableTypeAttributes`
- Changed endpoint sending to the server to `opc.tcp://{Target}:{Port}/{Path}` where:
  - `Target` passed from constructor instead of IP Address
  - `Path` a new constructor parameter for URL-path
- Several encode/decode fixes:
  - check null-array in decode methods (MaxValue in array size field)
  - use UTF8 instead ASCII for UAString
