### PR TITLE
Implement Register Nodes request

### DIFF
--- a/NET Core/LibUA/NetDispatcher.cs
+++ b/NET Core/LibUA/NetDispatcher.cs
@@ -2829,7 +2829,16 @@ namespace LibUA
 
 			protected int DispatchMessage_RegisterNodesRequest(SLChannel config, RequestHeader reqHeader, MemoryBuffer recvBuf, uint messageSize)
 			{
-				var respBuf = new MemoryBuffer(maximumMessageSize);
+                UInt32 noOfNodesToRegister;
+                if (!recvBuf.Decode(out noOfNodesToRegister)) { return ErrorParseFail; }
+
+                var nodesToRegister = new NodeId[noOfNodesToRegister];
+                for (uint i = 0; i < noOfNodesToRegister; i++)
+                {
+                    if (!recvBuf.Decode(out nodesToRegister[i])) { return ErrorParseFail; }
+                }
+
+                var respBuf = new MemoryBuffer(maximumMessageSize);
 				bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
 					(uint)RequestCode.RegisterNodesResponse, reqHeader, (uint)StatusCode.BadNotSupported);
 
@@ -2838,10 +2847,14 @@ namespace LibUA
 					return ErrorRespWrite;
 				}
 
-				// NoOfRegisteredNodeIds
-				succeeded &= respBuf.Encode((UInt32)0);
+                // NoOfRegisteredNodeIds
+                succeeded &= respBuf.Encode((UInt32)nodesToRegister.Length);
+                for (int i = 0; i < nodesToRegister.Length && succeeded; i++)
+                {
+                    succeeded &= respBuf.Encode(nodesToRegister[i]);
+                }
 
-				if (!succeeded)
+                if (!succeeded)
 				{
 					return ErrorRespWrite;
 				}

--- a/NET/LibUA/NetDispatcher.cs
+++ b/NET/LibUA/NetDispatcher.cs
@@ -2828,7 +2828,16 @@ namespace LibUA
 
 			protected int DispatchMessage_RegisterNodesRequest(SLChannel config, RequestHeader reqHeader, MemoryBuffer recvBuf, uint messageSize)
 			{
-				var respBuf = new MemoryBuffer(maximumMessageSize);
+                UInt32 noOfNodesToRegister;
+                if (!recvBuf.Decode(out noOfNodesToRegister)) { return ErrorParseFail; }
+
+                var nodesToRegister = new NodeId[noOfNodesToRegister];
+                for (uint i = 0; i < noOfNodesToRegister; i++)
+                {
+                    if (!recvBuf.Decode(out nodesToRegister[i])) { return ErrorParseFail; }
+                }
+
+                var respBuf = new MemoryBuffer(maximumMessageSize);
 				bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
 					(uint)RequestCode.RegisterNodesResponse, reqHeader, (uint)StatusCode.BadNotSupported);
 
@@ -2837,10 +2846,14 @@ namespace LibUA
 					return ErrorRespWrite;
 				}
 
-				// NoOfRegisteredNodeIds
-				succeeded &= respBuf.Encode((UInt32)0);
+                // NoOfRegisteredNodeIds
+                succeeded &= respBuf.Encode((UInt32)nodesToRegister.Length);
+                for (int i = 0; i < nodesToRegister.Length && succeeded; i++)
+                {
+                    succeeded &= respBuf.Encode(nodesToRegister[i]);
+                }
 
-				if (!succeeded)
+                if (!succeeded)
 				{
 					return ErrorRespWrite;
 				}


### PR DESCRIPTION
Hi,
Thank you for this incredible work!

I was trying to use the [Telegraf ](https://www.influxdata.com/time-series-platform/telegraf/) OPC-UA [plugin](https://www.influxdata.com/integration/opcua/) to gather data from an OPC UA server implemented using LibUA and store it into an [InfluxDB ](https://www.influxdata.com) metric.
 
This gave me the following error message in Telegraf.
> [inputs.opcua] Error in plugin: registerNodes failed: The requested operation is not supported.

I quickly realized that the `NetDispatcher` returns a `BadNotSupported` status code in its `DispatchMessage_RegisterNodesRequest` method.

I have limited knowledge of OPC UA but a rather naive implementation of the RegisterNodes service (following the OPC UA Online [Reference](https://reference.opcfoundation.org/v104/Core/docs/Part4/5.8.5/)) unlocked the situation with Telegraf.

With this PR, the `DispatchMessage_RegisterNodesRequest` method will return a `Good` status and `registeredNodeIds` equal to `nodesToRegister`.

Thanks for taking a look.
