### PR TITLE
Add DataChangeFilter

### DIFF
--- a/NET Core/LibUA/MemoryBufferExtensions.cs
+++ b/NET Core/LibUA/MemoryBufferExtensions.cs
@@ -870,6 +870,57 @@ namespace LibUA
 			return true;
 		}
 
+		public static bool Decode(this MemoryBuffer mem, out MonitoringFilter filter)
+		{
+			filter = null;
+
+			NodeId filterTypeId;
+			byte filterMask;
+
+			if (!mem.Decode(out filterTypeId)) { return false; }
+			if (!mem.Decode(out filterMask)) { return false; }
+
+			if (filterTypeId.EqualsNumeric(0, 0) && filterMask == 0)
+			{
+				// No filter
+				return true;
+			}
+			// Has binary body
+			if (filterMask != 1) { return false; }
+
+			UInt32 eoFilterSize;
+			if (!mem.Decode(out eoFilterSize)) { return false; }
+
+			if (filterTypeId.EqualsNumeric(0, (uint)UAConst.EventFilter_Encoding_DefaultBinary) &&
+				mem.Decode(out EventFilter eventFilter, false))
+			{
+				filter = eventFilter;
+				return true;
+			}
+			else if (filterTypeId.EqualsNumeric(0, (uint)UAConst.DataChangeFilter_Encoding_DefaultBinary) &&
+				mem.Decode(out DataChangeFilter dataChangeFilter, false))
+			{
+				filter = dataChangeFilter;
+				return true;
+			}
+
+			return false;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, MonitoringFilter filter, bool includeType)
+		{
+			if (filter is EventFilter eventFiler)
+			{
+				return mem.Encode(eventFiler, includeType);
+			}
+			else if (filter is DataChangeFilter dataChangeFilter)
+			{
+				return mem.Encode(dataChangeFilter, includeType);
+			}
+
+			return false;
+		}
+
 		public static bool Decode(this MemoryBuffer mem, out EventFilter filter, bool includeType)
 		{
 			filter = null;
@@ -1035,20 +1086,92 @@ namespace LibUA
 			return true;
 		}
 
+		public static bool Decode(this MemoryBuffer mem, out DataChangeFilter filter, bool includeType)
+		{
+			filter = null;
+
+			if (includeType)
+			{
+				NodeId filterTypeId;
+				byte filterMask;
+
+				if (!mem.Decode(out filterTypeId)) { return false; }
+				if (!mem.Decode(out filterMask)) { return false; }
+
+				if (filterTypeId.EqualsNumeric(0, 0) && filterMask == 0)
+				{
+					// No filter
+					return true;
+				}
+
+				if (!filterTypeId.EqualsNumeric(0, (uint)UAConst.DataChangeFilter_Encoding_DefaultBinary)) { return false; }
+				// Has binary body
+				if (filterMask != 1) { return false; }
+
+				UInt32 eoFilterSize;
+				if (!mem.Decode(out eoFilterSize)) { return false; }
+			}
+
+			UInt32 trigger, deadbandType;
+			if (!mem.Decode(out trigger)) { return false; }
+			if (!mem.Decode(out deadbandType)) { return false; }
+
+			double deadbandValue;
+			if (!mem.Decode(out deadbandValue)) { return false; }
+
+			try
+			{
+				filter = new DataChangeFilter((DataChangeTrigger)trigger, (DeadbandType)deadbandType, deadbandValue);
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, DataChangeFilter filter, bool includeType)
+		{
+            if (filter == null)
+            {
+                if (includeType)
+                {
+                    if (!mem.Encode(NodeId.Zero)) { return false; }
+                    if (!mem.Encode((byte)0)) { return false; }
+                }
+                return true;
+            }
+
+            if (includeType)
+            {
+                // Default binary
+                if (!mem.Encode(new NodeId(724))) { return false; }
+                // Has binary body
+                if (!mem.Encode((byte)1)) { return false; }
+            }
+
+            if (!mem.Encode((UInt32)filter.Trigger)) { return false; }
+            if (!mem.Encode((UInt32)filter.DeadbandType)) { return false; }
+            if (!mem.Encode(filter.DeadbandValue)) { return false; }
+
+            return true;
+        }
+
 		public static bool Decode(this MemoryBuffer mem, out MonitoringParameters para)
 		{
 			para = null;
 
 			UInt32 ClientHandle;
 			double SamplingInterval;
-			EventFilter Filter;
 			UInt32 QueueSize;
+            MonitoringFilter Filter;
 			bool DiscardOldest;
 
 			if (!mem.Decode(out ClientHandle)) { return false; }
 			if (!mem.Decode(out SamplingInterval)) { return false; }
 
-			if (!mem.Decode(out Filter, true)) { return false; }
+            if (!mem.Decode(out Filter)) { return false; }
 
 			if (!mem.Decode(out QueueSize)) { return false; }
 			if (!mem.Decode(out DiscardOldest)) { return false; }

--- a/NET Core/LibUA/NetDispatcher.cs
+++ b/NET Core/LibUA/NetDispatcher.cs
@@ -3210,19 +3210,7 @@ namespace LibUA
 						continue;
 					}
 
-					SimpleAttributeOperand[] filterSelectClauses = null;
-					if (createRequests[i].RequestedParameters.Filter != null)
-					{
-						filterSelectClauses = createRequests[i].RequestedParameters.Filter.SelectClauses;
-
-						//Console.WriteLine("Filter select clause {0}", filterSelectClauses.Length);
-						//foreach (var sc in filterSelectClauses)
-						//{
-						//	Console.WriteLine("Filter select clause \"{0}\"", string.Join(", ", sc.BrowsePath.Select(p => p.Name)));
-						//}
-					}
-
-					mi = new MonitoredItem(sub, filterSelectClauses)
+					mi = new MonitoredItem(sub)
 					{
 						MonitoredItemId = miHandle,
 
@@ -3365,7 +3353,6 @@ namespace LibUA
 
 					mi.QueueSize = Math.Max(1, Math.Min(MonitoredItem.MaxQueueSize, (int)modifyRequests[i].Parameters.QueueSize));
 					mi.Parameters = modifyRequests[i].Parameters;
-					mi.FilterSelectClauses = modifyRequests[i].Parameters.Filter.SelectClauses;
 					modifyResults[i] = new MonitoredItemModifyResult(StatusCode.Good, -1, (uint)mi.QueueSize, null);
 				}
 

--- a/NET Core/LibUA/Types.cs
+++ b/NET Core/LibUA/Types.cs
@@ -6577,7 +6577,9 @@ namespace LibUA
 			}
 		}
 
-		public class EventFilter
+		public abstract class MonitoringFilter { }
+
+		public class EventFilter : MonitoringFilter
 		{
 			public SimpleAttributeOperand[] SelectClauses { get; protected set; }
 			public ContentFilterElement[] ContentFilters { get; protected set; }
@@ -6589,15 +6591,29 @@ namespace LibUA
 			}
 		}
 
+		public class DataChangeFilter : MonitoringFilter
+		{
+			public DataChangeTrigger Trigger { get; protected set; }
+			public DeadbandType DeadbandType { get; protected set; }
+			public double DeadbandValue { get; protected set; }
+
+			public DataChangeFilter(DataChangeTrigger trigger, DeadbandType deadbandType, double deadbandValue)
+			{
+				this.Trigger = trigger;
+				this.DeadbandType = deadbandType;
+				this.DeadbandValue = deadbandValue;
+			}
+		}
+
 		public class MonitoringParameters
 		{
 			public UInt32 ClientHandle { get; protected set; }
 			public double SamplingInterval { get; protected set; }
-			public EventFilter Filter { get; protected set; }
+			public MonitoringFilter Filter { get; protected set; }
 			public UInt32 QueueSize { get; protected set; }
 			public bool DiscardOldest { get; protected set; }
 
-			public MonitoringParameters(UInt32 ClientHandle, double SamplingInterval, EventFilter Filter, UInt32 QueueSize, bool DiscardOldest)
+			public MonitoringParameters(UInt32 ClientHandle, double SamplingInterval, MonitoringFilter Filter, UInt32 QueueSize, bool DiscardOldest)
 			{
 				this.ClientHandle = ClientHandle;
 				this.SamplingInterval = SamplingInterval;
@@ -6755,15 +6771,25 @@ namespace LibUA
 			public Subscription ParentSubscription;
 
 			public ConcurrentQueue<EventNotification> QueueEvent;
-			public SimpleAttributeOperand[] FilterSelectClauses;
+			public SimpleAttributeOperand[] FilterSelectClauses
+			{
+				get
+				{
+					if (Parameters.Filter is EventFilter eventFiler)
+					{
+						return eventFiler.SelectClauses;
+					}
 
-			public MonitoredItem(Subscription ParentSubscription, SimpleAttributeOperand[] FilterSelectClauses = null)
+					return null;
+				}
+			}
+
+			public MonitoredItem(Subscription ParentSubscription)
 			{
 				this.ParentSubscription = ParentSubscription;
 
 				this.QueueData = new ConcurrentQueue<DataValue>();
 				this.QueueEvent = new ConcurrentQueue<EventNotification>();
-				this.FilterSelectClauses = FilterSelectClauses;
 
 				QueueOverflowed = false;
 			}

--- a/NET/LibUA/MemoryBufferExtensions.cs
+++ b/NET/LibUA/MemoryBufferExtensions.cs
@@ -384,6 +384,57 @@ namespace LibUA
 			return true;
 		}
 
+		public static bool Decode(this MemoryBuffer mem, out MonitoringFilter filter)
+		{
+			filter = null;
+
+			NodeId filterTypeId;
+			byte filterMask;
+
+			if (!mem.Decode(out filterTypeId)) { return false; }
+			if (!mem.Decode(out filterMask)) { return false; }
+
+			if (filterTypeId.EqualsNumeric(0, 0) && filterMask == 0)
+			{
+				// No filter
+				return true;
+			}
+			// Has binary body
+			if (filterMask != 1) { return false; }
+
+			UInt32 eoFilterSize;
+			if (!mem.Decode(out eoFilterSize)) { return false; }
+
+			if (filterTypeId.EqualsNumeric(0, (uint)UAConst.EventFilter_Encoding_DefaultBinary) &&
+				mem.Decode(out EventFilter eventFilter, false))
+			{
+				filter = eventFilter;
+				return true;
+			}
+			else if (filterTypeId.EqualsNumeric(0, (uint)UAConst.DataChangeFilter_Encoding_DefaultBinary) &&
+				mem.Decode(out DataChangeFilter dataChangeFilter, false))
+			{
+				filter = dataChangeFilter;
+				return true;
+			}
+
+			return false;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, MonitoringFilter filter, bool includeType)
+		{
+			if (filter is EventFilter eventFiler)
+			{
+				return mem.Encode(eventFiler, includeType);
+			}
+			else if (filter is DataChangeFilter dataChangeFilter)
+			{
+				return mem.Encode(dataChangeFilter, includeType);
+			}
+
+			return false;
+		}
+
 		public static bool Decode(this MemoryBuffer mem, out EventFilter filter, bool includeType)
 		{
 			filter = null;
@@ -549,20 +600,92 @@ namespace LibUA
 			return true;
 		}
 
+		public static bool Decode(this MemoryBuffer mem, out DataChangeFilter filter, bool includeType)
+		{
+			filter = null;
+
+			if (includeType)
+			{
+				NodeId filterTypeId;
+				byte filterMask;
+
+				if (!mem.Decode(out filterTypeId)) { return false; }
+				if (!mem.Decode(out filterMask)) { return false; }
+
+				if (filterTypeId.EqualsNumeric(0, 0) && filterMask == 0)
+				{
+					// No filter
+					return true;
+				}
+
+				if (!filterTypeId.EqualsNumeric(0, (uint)UAConst.DataChangeFilter_Encoding_DefaultBinary)) { return false; }
+				// Has binary body
+				if (filterMask != 1) { return false; }
+
+				UInt32 eoFilterSize;
+				if (!mem.Decode(out eoFilterSize)) { return false; }
+			}
+
+			UInt32 trigger, deadbandType;
+			if (!mem.Decode(out trigger)) { return false; }
+			if (!mem.Decode(out deadbandType)) { return false; }
+
+			double deadbandValue;
+			if (!mem.Decode(out deadbandValue)) { return false; }
+
+			try
+			{
+				filter = new DataChangeFilter((DataChangeTrigger)trigger, (DeadbandType)deadbandType, deadbandValue);
+			}
+			catch
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool Encode(this MemoryBuffer mem, DataChangeFilter filter, bool includeType)
+		{
+			if (filter == null)
+			{
+				if (includeType)
+				{
+					if (!mem.Encode(NodeId.Zero)) { return false; }
+					if (!mem.Encode((byte)0)) { return false; }
+				}
+				return true;
+			}
+
+			if (includeType)
+			{
+				// Default binary
+				if (!mem.Encode(new NodeId(724))) { return false; }
+				// Has binary body
+				if (!mem.Encode((byte)1)) { return false; }
+			}
+
+			if (!mem.Encode((UInt32)filter.Trigger)) { return false; }
+			if (!mem.Encode((UInt32)filter.DeadbandType)) { return false; }
+			if (!mem.Encode(filter.DeadbandValue)) { return false; }
+
+			return true;
+		}
+
 		public static bool Decode(this MemoryBuffer mem, out MonitoringParameters para)
 		{
 			para = null;
 
 			UInt32 ClientHandle;
 			double SamplingInterval;
-			EventFilter Filter;
+			MonitoringFilter Filter;
 			UInt32 QueueSize;
 			bool DiscardOldest;
 
 			if (!mem.Decode(out ClientHandle)) { return false; }
 			if (!mem.Decode(out SamplingInterval)) { return false; }
 
-			if (!mem.Decode(out Filter, true)) { return false; }
+			if (!mem.Decode(out Filter)) { return false; }
 
 			if (!mem.Decode(out QueueSize)) { return false; }
 			if (!mem.Decode(out DiscardOldest)) { return false; }

--- a/NET/LibUA/NetDispatcher.cs
+++ b/NET/LibUA/NetDispatcher.cs
@@ -3182,19 +3182,7 @@ namespace LibUA
 						continue;
 					}
 
-					SimpleAttributeOperand[] filterSelectClauses = null;
-					if (createRequests[i].RequestedParameters.Filter != null)
-					{
-						filterSelectClauses = createRequests[i].RequestedParameters.Filter.SelectClauses;
-
-						//Console.WriteLine("Filter select clause {0}", filterSelectClauses.Length);
-						//foreach (var sc in filterSelectClauses)
-						//{
-						//	Console.WriteLine("Filter select clause \"{0}\"", string.Join(", ", sc.BrowsePath.Select(p => p.Name)));
-						//}
-					}
-
-					mi = new MonitoredItem(sub, filterSelectClauses)
+					mi = new MonitoredItem(sub)
 					{
 						MonitoredItemId = miHandle,
 
@@ -3337,7 +3325,6 @@ namespace LibUA
 
 					mi.QueueSize = Math.Max(1, Math.Min(MonitoredItem.MaxQueueSize, (int)modifyRequests[i].Parameters.QueueSize));
 					mi.Parameters = modifyRequests[i].Parameters;
-					mi.FilterSelectClauses = modifyRequests[i].Parameters.Filter.SelectClauses;
 					modifyResults[i] = new MonitoredItemModifyResult(StatusCode.Good, -1, (uint)mi.QueueSize, null);
 				}
 


### PR DESCRIPTION
I was experiencing issues to establish a connection using the [Data Change Filter](https://reference.opcfoundation.org/Core/Part4/v104/docs/7.17.2) and found it unimplemented, as you clearly state in #38.

This is adding the most simplistic implementation of the Data Change Filter which will have the subscription request succeed while not implementing any filtering mechanism so it will generate notifications regardless of the Data Change Filter configuration.