### PR TITLE
Change MemoryBuffer to use ArrayPool

### DIFF
--- a/NET Core/LibUA/Client.cs
+++ b/NET Core/LibUA/Client.cs
@@ -141,7 +141,7 @@ namespace LibUA
             {
                 cs.WaitOne();
 
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
 
                 if (requestType == SecurityTokenRequestType.Issue)
                 {
@@ -472,7 +472,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false, MessageType.Close);
                 if (headerRes != StatusCode.Good)
                 {
@@ -550,7 +550,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -649,7 +649,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -760,7 +760,7 @@ namespace LibUA
             if (numChunks > 1)
             {
                 //Console.WriteLine("{0} -> {1} chunks", respBuf.Position, numChunks);
-                var chunk = new MemoryBuffer(chunkSize + ChunkHeaderOverhead + TLPaddingOverhead);
+                using var chunk = new MemoryBuffer(chunkSize + ChunkHeaderOverhead + TLPaddingOverhead);
                 for (int i = 0; i < numChunks; i++)
                 {
                     bool isFinal = i == numChunks - 1;
@@ -892,7 +892,7 @@ namespace LibUA
 
         private StatusCode SendHello()
         {
-            var sendBuf = new MemoryBuffer(MaximumMessageSize);
+            using var sendBuf = new MemoryBuffer(MaximumMessageSize);
 
             config.TL = new TLConnection
             {
@@ -1298,7 +1298,7 @@ namespace LibUA
                 return null;
             }
 
-            MemoryBuffer tmpBuf = new MemoryBuffer(buf.Capacity);
+            using MemoryBuffer tmpBuf = new MemoryBuffer(buf.Capacity);
             MemoryBuffer recvBuf = new MemoryBuffer(buf.Capacity);
 
             uint readOffset = 0;
@@ -1594,7 +1594,7 @@ namespace LibUA
             {
                 cs.WaitOne();
 
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -1838,7 +1838,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -1958,7 +1958,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2045,7 +2045,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2153,7 +2153,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2257,7 +2257,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2361,7 +2361,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2465,7 +2465,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2569,7 +2569,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2673,7 +2673,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2799,7 +2799,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -2924,7 +2924,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -3158,7 +3158,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -3276,7 +3276,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -3380,7 +3380,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -3523,7 +3523,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -3629,7 +3629,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -3728,7 +3728,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -3826,7 +3826,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -3925,7 +3925,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -4026,7 +4026,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -4127,7 +4127,7 @@ namespace LibUA
             try
             {
                 cs.WaitOne();
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {
@@ -4333,7 +4333,7 @@ namespace LibUA
 
             try
             {
-                var sendBuf = new MemoryBuffer(MaximumMessageSize);
+                using var sendBuf = new MemoryBuffer(MaximumMessageSize);
                 var headerRes = EncodeMessageHeader(sendBuf, false);
                 if (headerRes != StatusCode.Good)
                 {

--- a/NET Core/LibUA/NetDispatcher.cs
+++ b/NET Core/LibUA/NetDispatcher.cs
@@ -99,7 +99,7 @@ namespace LibUA
                 var req = pendingNotificationRequests.Dequeue();
                 req.Timestamp = DateTime.Now;
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.PublishResponse, req, (uint)StatusCode.Good);
 
@@ -300,7 +300,7 @@ namespace LibUA
                 var req = pendingNotificationRequests.Dequeue();
                 req.Timestamp = DateTime.Now;
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.PublishResponse, req, (uint)StatusCode.Good);
 
@@ -859,7 +859,7 @@ namespace LibUA
 
                 if (!recvBuf.DecodeUAByteString(out _)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.ActivateSessionResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -945,7 +945,7 @@ namespace LibUA
                     return ErrorInternal;
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.CreateSessionResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -1050,7 +1050,7 @@ namespace LibUA
 
                 if (!recvBuf.DecodeUAString(out string[] _)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.FindServersResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -1089,7 +1089,7 @@ namespace LibUA
 
                 if (!recvBuf.DecodeUAString(out string[] _)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.GetEndpointsResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -1167,7 +1167,7 @@ namespace LibUA
                     return null;
                 }
 
-                MemoryBuffer tmpBuf = new MemoryBuffer(buf.Capacity);
+                using MemoryBuffer tmpBuf = new MemoryBuffer(buf.Capacity);
                 MemoryBuffer recvBuf = new MemoryBuffer(buf.Capacity);
 
                 uint readOffset = 0;
@@ -1263,7 +1263,7 @@ namespace LibUA
                     //Console.WriteLine("{0} -> {1} chunks", respBuf.Position, numChunks);
                     //var bigChunkBuffer = new MemoryBuffer((int)config.TL.RemoteConfig.MaxMessageSize);
 
-                    var chunk = new MemoryBuffer(chunkSize + ChunkHeaderOverhead + TLPaddingOverhead);
+                    using var chunk = new MemoryBuffer(chunkSize + ChunkHeaderOverhead + TLPaddingOverhead);
                     for (int i = 0; i < numChunks; i++)
                     {
                         bool isFinal = i == numChunks - 1;
@@ -1597,7 +1597,7 @@ namespace LibUA
                     }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = true;
                 succeeded &= respBuf.Encode((uint)(MessageType.Open) | ((uint)'F' << 24));
                 succeeded &= respBuf.Encode((UInt32)0);
@@ -1768,7 +1768,7 @@ namespace LibUA
                 //	}
                 //}
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = true;
                 succeeded &= respBuf.Encode((uint)(MessageType.Acknowledge) | ((uint)'F' << 24));
                 succeeded &= respBuf.Encode((UInt32)0);
@@ -1940,7 +1940,7 @@ namespace LibUA
 
                 if (!recvBuf.Decode(out uint numNodesToRead)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 int availableSpacePerRequest = (int)((config.TL.RemoteConfig.MaxMessageSize / Math.Max(1, numNodesToRead)) * UsableMessageSizeFactor) - respBuf.Position - TLPaddingOverhead;
 
                 bool succeeded;
@@ -2258,7 +2258,7 @@ namespace LibUA
                     if (!recvBuf.Decode(out readValueIds[i])) { return ErrorParseFail; }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.ReadResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2297,7 +2297,7 @@ namespace LibUA
 
                 if (!recvBuf.Decode(out int NoOfHistoryUpdateDetails)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 var historyUpdates = new HistoryUpdateData[NoOfHistoryUpdateDetails];
                 for (uint i = 0; i < NoOfHistoryUpdateDetails; i++)
                 {
@@ -2384,7 +2384,7 @@ namespace LibUA
                     if (!recvBuf.Decode(out writeValues[i])) { return ErrorParseFail; }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.WriteResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2437,7 +2437,7 @@ namespace LibUA
                     if (!recvBuf.Decode(out browseDescs[i])) { return ErrorParseFail; }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.BrowseResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2509,7 +2509,7 @@ namespace LibUA
                     if (!recvBuf.DecodeUAByteString(out browseContPoints[i])) { return ErrorParseFail; }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.BrowseNextResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2621,7 +2621,7 @@ namespace LibUA
                     if (!recvBuf.Decode(out BrowsePaths[i])) { return ErrorParseFail; }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.TranslateBrowsePathsToNodeIdsResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2676,7 +2676,7 @@ namespace LibUA
                     results[i] = app.HandleCallRequest(config.Session, reqs[i]);
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.CallResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2731,7 +2731,7 @@ namespace LibUA
                     if (!recvBuf.Decode(out nodesToRegister[i])) { return ErrorParseFail; }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.RegisterNodesResponse, reqHeader, (uint)StatusCode.BadNotSupported);
 
@@ -2766,7 +2766,7 @@ namespace LibUA
                 if (!recvBuf.Decode(out bool PublishingEnabled)) { return ErrorParseFail; }
                 if (!recvBuf.Decode(out byte Priority)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.CreateSubscriptionResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2833,7 +2833,7 @@ namespace LibUA
                     if (!recvBuf.Decode(out SubscriptionIds[i])) { return ErrorParseFail; }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.SetPublishingModeResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2873,7 +2873,7 @@ namespace LibUA
                 if (!recvBuf.Decode(out uint MaxNotificationsPerPublish)) { return ErrorParseFail; }
                 if (!recvBuf.Decode(out byte Priority)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded;
                 if (subscriptionMap.TryGetValue(SubscriptionId, out Subscription sub))
                 {
@@ -2923,7 +2923,7 @@ namespace LibUA
                     if (!recvBuf.Decode(out SubIds[i])) { return ErrorParseFail; }
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.DeleteSubscriptionsResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -2965,7 +2965,7 @@ namespace LibUA
 
             protected int DispatchMessage_TransferSubscriptionsRequest(SLChannel config, RequestHeader reqHeader, MemoryBuffer recvBuf, uint messageSize)
             {
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.TransferSubscriptionsResponse, reqHeader, (uint)StatusCode.BadNotSupported);
 
@@ -3077,7 +3077,7 @@ namespace LibUA
                     createResponses[i] = new MonitoredItemCreateResult(StatusCode.Good, createRequests[i].RequestedParameters.ClientHandle, samplingInterval, (uint)mi.QueueSize, null);
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.CreateMonitoredItemsResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -3113,7 +3113,7 @@ namespace LibUA
 
                 if (!recvBuf.Decode(out uint NoOfItemsToModify)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.SetMonitoringModeResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -3190,7 +3190,7 @@ namespace LibUA
                     modifyResults[i] = new MonitoredItemModifyResult(StatusCode.Good, -1, (uint)mi.QueueSize, null);
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.ModifyMonitoredItemsResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -3236,7 +3236,7 @@ namespace LibUA
                     sub = null;
                 }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.DeleteMonitoredItemsResponse, reqHeader, (uint)StatusCode.Good);
 
@@ -3287,7 +3287,7 @@ namespace LibUA
                 //if (!recvBuf.Decode(out SubscriptionId)) { return ErrorParseFail; }
                 //if (!recvBuf.Decode(out TimestampsToReturnUint)) { return ErrorParseFail; }
 
-                var respBuf = new MemoryBuffer(maximumMessageSize);
+                using var respBuf = new MemoryBuffer(maximumMessageSize);
                 bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                     (uint)RequestCode.RepublishResponse, reqHeader, (uint)StatusCode.BadNotSupported);
 
@@ -3346,7 +3346,7 @@ namespace LibUA
                 {
                     logger?.Log(LogLevel.Error, string.Format("{0}: Too many publish requests (max is {1}), sent BadTooManyPublishRequests", LoggerID(), 1));
 
-                    var respBuf = new MemoryBuffer(maximumMessageSize);
+                    using var respBuf = new MemoryBuffer(maximumMessageSize);
                     bool succeeded = DispatchMessage_WriteHeader(config, respBuf,
                         (uint)RequestCode.PublishRequest, reqHeader, (uint)StatusCode.BadTooManyPublishRequests);
 

--- a/NET Core/LibUA/Server.cs
+++ b/NET Core/LibUA/Server.cs
@@ -317,7 +317,7 @@ namespace LibUA
 
             private void TLError(uint statusCode)
             {
-                var respBuf = new MemoryBuffer(1 << 10);
+                using var respBuf = new MemoryBuffer(1 << 10);
                 bool succeeded = true;
                 succeeded &= respBuf.Encode((uint)(MessageType.Error) | ((uint)'F' << 24));
                 succeeded &= respBuf.Encode((UInt32)0);

--- a/NET Core/LibUA/Types.cs
+++ b/NET Core/LibUA/Types.cs
@@ -5825,7 +5825,7 @@ namespace LibUA
                 TypeId = null;
                 if (Payload != null)
                 {
-                    var buffer = new MemoryBuffer(BufferCapacity);
+                    using var buffer = new MemoryBuffer(BufferCapacity);
                     UAConst payloadType = 0;
 
                     if(_objectEncoders.TryGetValue(Payload.GetType(), out var encoder))


### PR DESCRIPTION
Fixes #151 

Switched to using ArrayPool in MemoryBuffer to increase performance and to reduce Allocation Pressure.

Here are some diagnostics before and after the switch:
Client Code:
![ClientCode](https://github.com/nauful/LibUA/assets/32666169/2609f9bb-a68d-48e7-b261-f0e71725fa81)

Client allocation rate without ArrayPool:
![ClientWithoutArrayPool](https://github.com/nauful/LibUA/assets/32666169/ad98e5bc-1dee-4ca1-b261-e0909fe197c8)

Server allocation rate without ArrayPool
![ServerWithoutArrayPool](https://github.com/nauful/LibUA/assets/32666169/94acee19-bbfe-4904-889f-7a19aaf03e94)

Throughput without ArrayPool
![ClientThroughputWithoutArrayPool](https://github.com/nauful/LibUA/assets/32666169/ec9e3c20-19a7-4d77-837c-857374743432)


Client allocation rate with ArrayPool:
![ClientWithArrayPool](https://github.com/nauful/LibUA/assets/32666169/e47ee3fc-5c7a-46e7-b4f7-31f088d0d3c2)

Server allocation rate with ArrayPool:
![ServerWithArrayPool](https://github.com/nauful/LibUA/assets/32666169/f6ac84fa-a519-4fe9-95c0-21ef7cb5bb94)

Throughput with ArrayPool:
![ClientThroughputWithArrayPool](https://github.com/nauful/LibUA/assets/32666169/67fdc4b5-830c-40ef-bbe7-cf4cf85e6ddf)
