### PR TITLE
Set `IsBackground` to true for connection thread

### DIFF
--- a/NET Core/LibUA/Client.cs
+++ b/NET Core/LibUA/Client.cs
@@ -874,6 +874,7 @@ namespace LibUA
 
                 threadAbort = false;
                 thread = new Thread(new ParameterizedThreadStart(ThreadTarget));
+                thread.IsBackground = true;
                 thread.Start(this);
 
                 var ret = SendHello();


### PR DESCRIPTION
When using LibUA in a UI application and the application is exited without first disconnecting the client, the thread created in `Client.Connect()` hangs.

This pull request sets the `IsBackground` property of the connection thread to `true`, so that the application can be closed, because the thread is then tied to the application thread.