### PR TITLE
Change CodingSize type methods to Static

### DIFF
--- a/NET Core/LibUA/AddressSpace.cs
+++ b/NET Core/LibUA/AddressSpace.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LibUA
 {

--- a/NET Core/LibUA/Application.cs
+++ b/NET Core/LibUA/Application.cs
@@ -3,12 +3,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Reflection.Metadata;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using LibUA.Core;
 
 namespace LibUA

--- a/NET Core/LibUA/Client.cs
+++ b/NET Core/LibUA/Client.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography;

--- a/NET Core/LibUA/Coding.cs
+++ b/NET Core/LibUA/Coding.cs
@@ -1,0 +1,338 @@
+﻿using System;
+using System.Text;
+
+namespace LibUA.Core;
+
+public class Coding
+{
+
+    public static int CodingSize(byte v) { return 1; }
+    public static int CodingSize(SByte v) { return 1; }
+    public static int CodingSize(bool v) { return 1; }
+    public static int CodingSize(Int16 v) { return 2; }
+    public static int CodingSize(UInt16 v) { return 2; }
+    public static int CodingSize(Int32 v) { return 4; }
+    public static int CodingSize(UInt32 v) { return 4; }
+    public static int CodingSize(Int64 v) { return 8; }
+    public static int CodingSize(UInt64 v) { return 8; }
+    public static int CodingSize(Single v) { return 4; }
+    public static int CodingSize(Double v) { return 8; }
+    public static int CodingSize(string s) { return CodingSize((int)s.Length) + s.Length; }
+    public static int CodingSize(NodeId id)
+    {
+        switch (id.IdType)
+        {
+            case NodeIdNetType.Numeric:
+                {
+                    if (id.NamespaceIndex == 0 && id.NumericIdentifier <= 0xFF)
+                    {
+                        return 2;
+                    }
+                    else if (id.NamespaceIndex <= 0xFF && id.NumericIdentifier <= 0xFFFF)
+                    {
+                        return 4;
+                    }
+                    else
+                    {
+                        return 7;
+                    }
+                }
+
+            case NodeIdNetType.String:
+                {
+                    return 3 + Coding.CodingSizeUAString(id.StringIdentifier);
+                }
+
+            default:
+                // TODO: Handle
+                throw new Exception();
+        }
+    }
+    public static int CodingSize(QualifiedName qn)
+    {
+        return Coding.CodingSize(qn.NamespaceIndex) + Coding.CodingSizeUAString(qn.Name);
+    }
+    public static int CodingSize(LocalizedText ad)
+    {
+        int size = Coding.CodingSize((byte)0);
+        if (!string.IsNullOrEmpty(ad.Locale)) { size += Coding.CodingSizeUAString(ad.Locale); }
+        if (!string.IsNullOrEmpty(ad.Text)) { size += Coding.CodingSizeUAString(ad.Text); }
+
+        return size;
+    }
+    public static int CodingSize(ExtensionObject obj)
+    {
+        int size = 0;
+
+        if (obj == null)
+        {
+            size = Coding.CodingSize(NodeId.Zero);
+            size += Coding.CodingSize((byte)ExtensionObjectBodyType.None);
+            return size;
+        }
+
+        size += Coding.CodingSize(obj.TypeId);
+        size += Coding.CodingSize((byte)ExtensionObjectBodyType.None);
+
+        if (obj.Body == null)
+        {
+            return size;
+        }
+
+        size += Coding.CodingSizeUAByteString(obj.Body);
+
+        return size;
+    }
+    public static int CodingSizeUAByteString(byte[] str)
+    {
+        if (str == null) { return Coding.CodingSize((UInt32)0); }
+
+        return Coding.CodingSize((UInt32)0) + str.Length;
+    }
+    public static int CodingSizeUAGuidByteString(byte[] str)
+    {
+        if (str == null) { return 0; }
+
+        return str.Length;
+    }
+    public static int CodingSizeUAString(string str)
+    {
+        if (str == null) { return Coding.CodingSize((UInt32)0); }
+
+        return Coding.CodingSize((UInt32)0) + Encoding.UTF8.GetBytes(str).Length;
+    }
+
+    public static Type GetNetType(VariantType type)
+    {
+        if (type == VariantType.Boolean) { return typeof(bool); }
+        if (type == VariantType.SByte) { return typeof(SByte); }
+        if (type == VariantType.Byte) { return typeof(Byte); }
+        if (type == VariantType.Int16) { return typeof(Int16); }
+        if (type == VariantType.UInt16) { return typeof(UInt16); }
+        if (type == VariantType.Int32) { return typeof(Int32); }
+        if (type == VariantType.UInt32) { return typeof(UInt32); }
+        if (type == VariantType.Int64) { return typeof(Int64); }
+        if (type == VariantType.UInt64) { return typeof(UInt64); }
+        if (type == VariantType.Float) { return typeof(float); }
+        if (type == VariantType.Double) { return typeof(Double); }
+        if (type == VariantType.NodeId) { return typeof(NodeId); }
+        if (type == VariantType.QualifiedName) { return typeof(QualifiedName); }
+        if (type == VariantType.LocalizedText) { return typeof(LocalizedText); }
+        if (type == VariantType.String) { return typeof(String); }
+        if (type == VariantType.ExtensionObject) { return typeof(ExtensionObject); }
+
+        // TODO: Other types
+
+        return null;
+    }
+
+    public static VariantType GetVariantTypeFromInstance(object obj)
+    {
+        if (obj is bool) { return VariantType.Boolean; }
+        if (obj is SByte) { return VariantType.SByte; }
+        if (obj is Byte) { return VariantType.Byte; }
+        if (obj is Int16) { return VariantType.Int16; }
+        if (obj is UInt16) { return VariantType.UInt16; }
+        if (obj is Int32) { return VariantType.Int32; }
+        if (obj is UInt32) { return VariantType.UInt32; }
+        if (obj is Int64) { return VariantType.Int64; }
+        if (obj is UInt64) { return VariantType.UInt64; }
+        if (obj is float) { return VariantType.Float; }
+        if (obj is Double) { return VariantType.Double; }
+        if (obj is string) { return VariantType.String; }
+        if (obj is byte[]) { return VariantType.ByteString; }
+        if (obj is NodeId) { return VariantType.NodeId; }
+        if (obj is QualifiedName) { return VariantType.QualifiedName; }
+        if (obj is LocalizedText) { return VariantType.LocalizedText; }
+        if (obj is DateTime) { return VariantType.DateTime; }
+        if (obj is StatusCode) { return VariantType.StatusCode; }
+        if (obj is ExtensionObject) { return VariantType.ExtensionObject; }
+
+        // TODO: Other types
+
+        return VariantType.Null;
+    }
+
+    public static VariantType GetVariantTypeFromType(Type type)
+    {
+        if (type == typeof(bool)) { return VariantType.Boolean; }
+        if (type == typeof(SByte)) { return VariantType.SByte; }
+        if (type == typeof(Byte)) { return VariantType.Byte; }
+        if (type == typeof(Int16)) { return VariantType.Int16; }
+        if (type == typeof(UInt16)) { return VariantType.UInt16; }
+        if (type == typeof(Int32)) { return VariantType.Int32; }
+        if (type == typeof(UInt32)) { return VariantType.UInt32; }
+        if (type == typeof(Int64)) { return VariantType.Int64; }
+        if (type == typeof(UInt64)) { return VariantType.UInt64; }
+        if (type == typeof(float)) { return VariantType.Float; }
+        if (type == typeof(Double)) { return VariantType.Double; }
+        if (type == typeof(string)) { return VariantType.String; }
+        if (type == typeof(byte[])) { return VariantType.ByteString; }
+        if (type == typeof(NodeId)) { return VariantType.NodeId; }
+        if (type == typeof(QualifiedName)) { return VariantType.QualifiedName; }
+        if (type == typeof(LocalizedText)) { return VariantType.LocalizedText; }
+        if (type == typeof(DateTime)) { return VariantType.DateTime; }
+        if (type == typeof(StatusCode)) { return VariantType.StatusCode; }
+        if (type == typeof(ExtensionObject)) { return VariantType.ExtensionObject; }
+
+        // TODO: Other types
+
+        return VariantType.Null;
+    }
+
+    public static int VariantCodingSize(object obj)
+    {
+        int rank = 0;
+        VariantType varType;
+        if (obj is Array && !(obj is byte[]))
+        {
+            var type = obj.GetType();
+            rank = type.GetArrayRank();
+            type = type.GetElementType();
+
+            varType = GetVariantTypeFromType(type);
+        }
+        else
+        {
+            varType = GetVariantTypeFromInstance(obj);
+        }
+
+        int size = 0;
+
+        byte mask = (byte)varType;
+        ++size;
+
+        if (rank > 1)
+        {
+            mask |= 0x40;
+        }
+
+        if (rank >= 1)
+        {
+            mask |= 0x80;
+            size += CodingSize((int)((Array)obj).Length);
+
+            foreach (var value in obj as Array)
+            {
+                size += VariantCodingSize(value, mask);
+            }
+
+            if (rank > 1)
+            {
+                size += CodingSize((int)rank) * (1 + rank);
+            }
+        }
+        else
+        {
+            size += VariantCodingSize(obj, mask);
+        }
+
+        return size;
+    }
+
+    public static int VarLenU32Decode(out UInt32 v, byte[] Src)
+    {
+        v = 0;
+
+        for (int i = 0, n = 0; i < 5; i++, n += 7)
+        {
+            int curLen = 1 + i;
+            if (Src.Length < curLen)
+            {
+                return -1;
+            }
+
+            v |= (uint)(((byte)(Src[i] >> 1) & 0x7F) << n);
+            if ((Src[i] & 1) != 0)
+            {
+                continue;
+            }
+
+            return curLen;
+        }
+
+        return 0;
+    }
+
+    public static int VarLenU32Encode(UInt32 v, byte[] Dest)
+    {
+        for (int i = 0, n = 0; i < 5; i++, n += 7)
+        {
+            if (i == 4 && (v >> n) > 0x7F)
+            {
+                // Overflow
+                break;
+            }
+
+            Dest[i] = (byte)(((v >> n) & 0x7F) << 1);
+            if ((v >> n) < 0x80)
+            {
+                return i + 1;
+            }
+
+            Dest[i] |= 1;
+        }
+
+        // Overflow
+        return 0;
+    }
+
+    public static int VarLenU32Size(UInt32 v)
+    {
+        for (int i = 0, n = 0; i < 5; i++, n += 7)
+        {
+            if (i == 4 && (v >> n) > 0x7F)
+            {
+                // Overflow
+                break;
+            }
+
+            if ((v >> n) < 0x80)
+            {
+                return i + 1;
+            }
+        }
+
+        // Overflow
+        return 0;
+    }
+
+    private static int VariantCodingSize(object obj, byte mask)
+    {
+        int size = 0;
+
+        switch (mask & 0x3F)
+        {
+            case (int)VariantType.Null: break;
+            case (int)VariantType.Boolean: size += CodingSize((bool)obj); break;
+            case (int)VariantType.SByte: size += CodingSize((SByte)obj); break;
+            case (int)VariantType.Byte: size += CodingSize((Byte)obj); break;
+            case (int)VariantType.Int16: size += CodingSize((Int16)obj); break;
+            case (int)VariantType.UInt16: size += CodingSize((UInt16)obj); break;
+            case (int)VariantType.Int32: size += CodingSize((Int32)obj); break;
+            case (int)VariantType.UInt32: size += CodingSize((UInt32)obj); break;
+            case (int)VariantType.Int64: size += CodingSize((Int64)obj); break;
+            case (int)VariantType.UInt64: size += CodingSize((UInt64)obj); break;
+            case (int)VariantType.Float: size += CodingSize((Single)obj); break;
+            case (int)VariantType.Double: size += CodingSize((Double)obj); break;
+            case (int)VariantType.String: size += CodingSizeUAString((string)obj); break;
+            case (int)VariantType.DateTime: size += CodingSize((Int64)0); break;
+            //case (int)VariantType.Guid: size += CodingSize((int)obj); break;
+            case (int)VariantType.ByteString: size += CodingSizeUAByteString((byte[])obj); break;
+            //case (int)VariantType.XmlElement: size += CodingSize((int)obj); break;
+            case (int)VariantType.NodeId: size += CodingSize((NodeId)obj); break;
+            //case (int)VariantType.ExpandedNodeId: size += CodingSize((int)obj); break;
+            case (int)VariantType.StatusCode: size += CodingSize((UInt32)obj); break;
+            case (int)VariantType.QualifiedName: size += CodingSize((QualifiedName)obj); break;
+            case (int)VariantType.LocalizedText: size += CodingSize((LocalizedText)obj); break;
+            case (int)VariantType.ExtensionObject: size += CodingSize((ExtensionObject)obj); break;
+            //case (int)VariantType.DataValue: size += CodingSize((int)obj); break;
+            //case (int)VariantType.Variant: size += CodingSize((int)obj); break;
+            //case (int)VariantType.DiagnosticInfo: size += CodingSize((int)obj); break;
+            default:
+                throw new Exception("TODO");
+        }
+
+        return size;
+    }
+}

--- a/NET Core/LibUA/MemoryBuffer.cs
+++ b/NET Core/LibUA/MemoryBuffer.cs
@@ -1,45 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Buffers;
 
 namespace LibUA
 {
     namespace Core
     {
-        public static class ArrayHelper
-        {
-            public static T[] SubArray<T>(this T[] Data, int Offset, int Length)
-            {
-                var res = new T[Length];
-                Array.Copy(Data, Offset, res, 0, Length);
-
-                return res;
-            }
-
-            public static void Memset<T>(this T[] Data, T Value)
-            {
-                int BlockSize = 32;
-                int Index = 0;
-
-                int Length = Math.Min(BlockSize, Data.Length);
-                while (Index < Length)
-                {
-                    Data[Index++] = Value;
-                }
-
-                Length = Data.Length;
-                while (Index < Length)
-                {
-                    Buffer.BlockCopy(Data, 0, Data, Index, Math.Min(BlockSize, Length - Index));
-                    Index += BlockSize;
-                    BlockSize *= 2;
-                }
-            }
-        }
-
-        public class MemoryBuffer
+        public class MemoryBuffer : IDisposable
         {
             public bool IsReadOnly { get; protected set; }
 
@@ -132,14 +98,46 @@ namespace LibUA
                 }
             }
 
+            private bool isRented;
             public MemoryBuffer(int Size)
             {
                 Position = 0;
                 IsReadOnly = false;
                 IsFixedCapacity = true;
 
-                Buffer = new byte[Size];
+                Buffer = ArrayPool<byte>.Shared.Rent(Size);
                 Capacity = Allocated = Size;
+                isRented = true;
+            }
+
+            private bool disposed;
+
+            public void Dispose()
+            {
+                if (!isRented)
+                    return;
+
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!disposed)
+                {
+                    if (disposing)
+                    {
+                        // Return the array back to the pool
+                        ArrayPool<byte>.Shared.Return(Buffer);
+                    }
+
+                    disposed = true;
+                }
+            }
+
+            ~MemoryBuffer()
+            {
+                Dispose(false);
             }
 
             public bool EnsureAvailable(int Length, bool readOnly)
@@ -248,41 +246,6 @@ namespace LibUA
                 if (!EnsureAvailable(Size, true)) { return false; }
 
                 Array.Copy(Buffer, Position, Dest, 0, Size);
-                Position += Size;
-
-                return true;
-            }
-
-            public bool Prepend(byte[] Add, int Size)
-            {
-                if (Add == null || Size > Add.Length)
-                {
-                    return false;
-                }
-
-                if (Size == 0)
-                {
-                    return true;
-                }
-
-                if (!EnsureAvailable(Size, false))
-                {
-                    return false;
-                }
-
-                var tmp = new byte[Position];
-                if (Position > 0)
-                {
-                    Array.Copy(Buffer, tmp, Position);
-                }
-
-                Array.Copy(Add, Buffer, Size);
-
-                if (Position > 0)
-                {
-                    Array.Copy(tmp, 0, Buffer, Size, Position);
-                }
-
                 Position += Size;
 
                 return true;
@@ -573,87 +536,6 @@ namespace LibUA
                 return true;
             }
 
-            public int CodingSize(byte v) { return 1; }
-            public int CodingSize(SByte v) { return 1; }
-            public int CodingSize(bool v) { return 1; }
-            public int CodingSize(Int16 v) { return 2; }
-            public int CodingSize(UInt16 v) { return 2; }
-            public int CodingSize(Int32 v) { return 4; }
-            public int CodingSize(UInt32 v) { return 4; }
-            public int CodingSize(Int64 v) { return 8; }
-            public int CodingSize(UInt64 v) { return 8; }
-            public int CodingSize(Single v) { return 4; }
-            public int CodingSize(Double v) { return 8; }
-
-            public int CodingSize(string s) { return CodingSize((int)s.Length) + s.Length; }
-
-            public static int VarLenU32Decode(out UInt32 v, byte[] Src)
-            {
-                v = 0;
-
-                for (int i = 0, n = 0; i < 5; i++, n += 7)
-                {
-                    int curLen = 1 + i;
-                    if (Src.Length < curLen)
-                    {
-                        return -1;
-                    }
-
-                    v |= (uint)(((byte)(Src[i] >> 1) & 0x7F) << n);
-                    if ((Src[i] & 1) != 0)
-                    {
-                        continue;
-                    }
-
-                    return curLen;
-                }
-
-                return 0;
-            }
-
-            public static int VarLenU32Encode(UInt32 v, byte[] Dest)
-            {
-                for (int i = 0, n = 0; i < 5; i++, n += 7)
-                {
-                    if (i == 4 && (v >> n) > 0x7F)
-                    {
-                        // Overflow
-                        break;
-                    }
-
-                    Dest[i] = (byte)(((v >> n) & 0x7F) << 1);
-                    if ((v >> n) < 0x80)
-                    {
-                        return i + 1;
-                    }
-
-                    Dest[i] |= 1;
-                }
-
-                // Overflow
-                return 0;
-            }
-
-            public static int VarLenU32Size(UInt32 v)
-            {
-                for (int i = 0, n = 0; i < 5; i++, n += 7)
-                {
-                    if (i == 4 && (v >> n) > 0x7F)
-                    {
-                        // Overflow
-                        break;
-                    }
-
-                    if ((v >> n) < 0x80)
-                    {
-                        return i + 1;
-                    }
-                }
-
-                // Overflow
-                return 0;
-            }
-
             public int VarLenU32Decode(out UInt32 v)
             {
                 int len = Capacity - Position;
@@ -666,7 +548,7 @@ namespace LibUA
                     Array.Copy(Buffer, Position, tmp, 0, bufLen);
                 }
 
-                int adv = VarLenU32Decode(out v, tmp);
+                int adv = Coding.VarLenU32Decode(out v, tmp);
                 if (adv > 0)
                 {
                     Position += adv;
@@ -679,142 +561,13 @@ namespace LibUA
             {
                 var buffer = new byte[8];
 
-                int adv = VarLenU32Encode(v, buffer);
+                int adv = Coding.VarLenU32Encode(v, buffer);
                 if (adv > 0)
                 {
                     Append(buffer, adv);
                 }
 
                 return adv;
-            }
-
-            public static VariantType GetVariantTypeFromType(Type type)
-            {
-                if (type == typeof(bool)) { return VariantType.Boolean; }
-                if (type == typeof(SByte)) { return VariantType.SByte; }
-                if (type == typeof(Byte)) { return VariantType.Byte; }
-                if (type == typeof(Int16)) { return VariantType.Int16; }
-                if (type == typeof(UInt16)) { return VariantType.UInt16; }
-                if (type == typeof(Int32)) { return VariantType.Int32; }
-                if (type == typeof(UInt32)) { return VariantType.UInt32; }
-                if (type == typeof(Int64)) { return VariantType.Int64; }
-                if (type == typeof(UInt64)) { return VariantType.UInt64; }
-                if (type == typeof(float)) { return VariantType.Float; }
-                if (type == typeof(Double)) { return VariantType.Double; }
-                if (type == typeof(string)) { return VariantType.String; }
-                if (type == typeof(byte[])) { return VariantType.ByteString; }
-                if (type == typeof(NodeId)) { return VariantType.NodeId; }
-                if (type == typeof(QualifiedName)) { return VariantType.QualifiedName; }
-                if (type == typeof(LocalizedText)) { return VariantType.LocalizedText; }
-                if (type == typeof(DateTime)) { return VariantType.DateTime; }
-                if (type == typeof(StatusCode)) { return VariantType.StatusCode; }
-                if (type == typeof(ExtensionObject)) { return VariantType.ExtensionObject; }
-
-                // TODO: Other types
-
-                return VariantType.Null;
-            }
-
-
-            public static VariantType GetVariantTypeFromInstance(object obj)
-            {
-                if (obj is bool) { return VariantType.Boolean; }
-                if (obj is SByte) { return VariantType.SByte; }
-                if (obj is Byte) { return VariantType.Byte; }
-                if (obj is Int16) { return VariantType.Int16; }
-                if (obj is UInt16) { return VariantType.UInt16; }
-                if (obj is Int32) { return VariantType.Int32; }
-                if (obj is UInt32) { return VariantType.UInt32; }
-                if (obj is Int64) { return VariantType.Int64; }
-                if (obj is UInt64) { return VariantType.UInt64; }
-                if (obj is float) { return VariantType.Float; }
-                if (obj is Double) { return VariantType.Double; }
-                if (obj is string) { return VariantType.String; }
-                if (obj is byte[]) { return VariantType.ByteString; }
-                if (obj is NodeId) { return VariantType.NodeId; }
-                if (obj is QualifiedName) { return VariantType.QualifiedName; }
-                if (obj is LocalizedText) { return VariantType.LocalizedText; }
-                if (obj is DateTime) { return VariantType.DateTime; }
-                if (obj is StatusCode) { return VariantType.StatusCode; }
-                if (obj is ExtensionObject) { return VariantType.ExtensionObject; }
-
-                // TODO: Other types
-
-                return VariantType.Null;
-            }
-
-            public static Type GetNetType(VariantType type)
-            {
-                if (type == VariantType.Boolean) { return typeof(bool); }
-                if (type == VariantType.SByte) { return typeof(SByte); }
-                if (type == VariantType.Byte) { return typeof(Byte); }
-                if (type == VariantType.Int16) { return typeof(Int16); }
-                if (type == VariantType.UInt16) { return typeof(UInt16); }
-                if (type == VariantType.Int32) { return typeof(Int32); }
-                if (type == VariantType.UInt32) { return typeof(UInt32); }
-                if (type == VariantType.Int64) { return typeof(Int64); }
-                if (type == VariantType.UInt64) { return typeof(UInt64); }
-                if (type == VariantType.Float) { return typeof(float); }
-                if (type == VariantType.Double) { return typeof(Double); }
-                if (type == VariantType.NodeId) { return typeof(NodeId); }
-                if (type == VariantType.QualifiedName) { return typeof(QualifiedName); }
-                if (type == VariantType.LocalizedText) { return typeof(LocalizedText); }
-                if (type == VariantType.String) { return typeof(String); }
-                if (type == VariantType.ExtensionObject) { return typeof(ExtensionObject); }
-
-                // TODO: Other types
-
-                return null;
-            }
-
-            public int VariantCodingSize(object obj)
-            {
-                int rank = 0;
-                VariantType varType;
-                if (obj is Array && !(obj is byte[]))
-                {
-                    var type = obj.GetType();
-                    rank = type.GetArrayRank();
-                    type = type.GetElementType();
-
-                    varType = GetVariantTypeFromType(type);
-                }
-                else
-                {
-                    varType = GetVariantTypeFromInstance(obj);
-                }
-
-                int size = 0;
-
-                byte mask = (byte)varType;
-                ++size;
-
-                if (rank > 1)
-                {
-                    mask |= 0x40;
-                }
-
-                if (rank >= 1)
-                {
-                    mask |= 0x80;
-                    size += CodingSize((int)((Array)obj).Length);
-
-                    foreach (var value in obj as Array)
-                    {
-                        size += VariantCodingSize(value, mask);
-                    }
-
-                    if (rank > 1)
-                    {
-                        size += CodingSize((int)rank) * (1 + rank);
-                    }
-                }
-                else
-                {
-                    size += VariantCodingSize(obj, mask);
-                }
-
-                return size;
             }
 
             public bool VariantEncode(object obj)
@@ -827,11 +580,11 @@ namespace LibUA
                     rank = type.GetArrayRank();
                     type = type.GetElementType();
 
-                    varType = GetVariantTypeFromType(type);
+                    varType = Coding.GetVariantTypeFromType(type);
                 }
                 else
                 {
-                    varType = GetVariantTypeFromInstance(obj);
+                    varType = Coding.GetVariantTypeFromInstance(obj);
                 }
 
                 byte mask = (byte)varType;
@@ -892,8 +645,7 @@ namespace LibUA
                 {
                     if (!Decode(out int arrLen)) { return false; }
                     if (arrLen < 0) { return false; }
-
-                    Type type = GetNetType((VariantType)(mask & 0x3F));
+                    Type type = Coding.GetNetType((VariantType)(mask & 0x3F));
 
                     var arr = Array.CreateInstance(type, arrLen);
                     for (int i = 0; i < arrLen; i++)
@@ -928,45 +680,6 @@ namespace LibUA
                 }
 
                 return true;
-            }
-
-            private int VariantCodingSize(object obj, byte mask)
-            {
-                int size = 0;
-
-                switch (mask & 0x3F)
-                {
-                    case (int)VariantType.Null: break;
-                    case (int)VariantType.Boolean: size += CodingSize((bool)obj); break;
-                    case (int)VariantType.SByte: size += CodingSize((SByte)obj); break;
-                    case (int)VariantType.Byte: size += CodingSize((Byte)obj); break;
-                    case (int)VariantType.Int16: size += CodingSize((Int16)obj); break;
-                    case (int)VariantType.UInt16: size += CodingSize((UInt16)obj); break;
-                    case (int)VariantType.Int32: size += CodingSize((Int32)obj); break;
-                    case (int)VariantType.UInt32: size += CodingSize((UInt32)obj); break;
-                    case (int)VariantType.Int64: size += CodingSize((Int64)obj); break;
-                    case (int)VariantType.UInt64: size += CodingSize((UInt64)obj); break;
-                    case (int)VariantType.Float: size += CodingSize((Single)obj); break;
-                    case (int)VariantType.Double: size += CodingSize((Double)obj); break;
-                    case (int)VariantType.String: size += this.CodingSizeUAString((string)obj); break;
-                    case (int)VariantType.DateTime: size += CodingSize((Int64)0); break;
-                    //case (int)VariantType.Guid: size += CodingSize((int)obj); break;
-                    case (int)VariantType.ByteString: size += this.CodingSizeUAByteString((byte[])obj); break;
-                    //case (int)VariantType.XmlElement: size += CodingSize((int)obj); break;
-                    case (int)VariantType.NodeId: size += this.CodingSize((NodeId)obj); break;
-                    //case (int)VariantType.ExpandedNodeId: size += CodingSize((int)obj); break;
-                    case (int)VariantType.StatusCode: size += CodingSize((UInt32)obj); break;
-                    case (int)VariantType.QualifiedName: size += this.CodingSize((QualifiedName)obj); break;
-                    case (int)VariantType.LocalizedText: size += this.CodingSize((LocalizedText)obj); break;
-                    case (int)VariantType.ExtensionObject: size += this.CodingSize((ExtensionObject)obj); break;
-                    //case (int)VariantType.DataValue: size += CodingSize((int)obj); break;
-                    //case (int)VariantType.Variant: size += CodingSize((int)obj); break;
-                    //case (int)VariantType.DiagnosticInfo: size += CodingSize((int)obj); break;
-                    default:
-                        throw new Exception("TODO");
-                }
-
-                return size;
             }
 
             public bool VariantEncode(object obj, byte mask)

--- a/NET Core/LibUA/NetDispatcher.cs
+++ b/NET Core/LibUA/NetDispatcher.cs
@@ -134,7 +134,7 @@ namespace LibUA
                         int sizeRequired = 4 + 4;
                         for (int i = 0; i < fields.Length; i++)
                         {
-                            sizeRequired += respBuf.VariantCodingSize(fields[i]);
+                            sizeRequired += Coding.VariantCodingSize(fields[i]);
                         }
 
                         // ClientHandle + numEventFields + ev
@@ -2067,7 +2067,7 @@ namespace LibUA
                                 int sizeRequired = 4;
                                 for (int k = 0; k < resultsEvents[j].Length; k++)
                                 {
-                                    sizeRequired += respBuf.VariantCodingSize(resultsEvents[j][k]);
+                                    sizeRequired += Coding.VariantCodingSize(resultsEvents[j][k]);
                                 }
 
                                 if (availableSpace < sizeRequired)

--- a/NET Core/LibUA/Server.cs
+++ b/NET Core/LibUA/Server.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using LibUA.Core;
 using Microsoft.Extensions.Logging;
 

--- a/NET Core/LibUA/ValueTypes/EUInformation.cs
+++ b/NET Core/LibUA/ValueTypes/EUInformation.cs
@@ -17,10 +17,10 @@ public static class EUInformationExtensions
     {
         int sum = 0;
 
-        sum += mem.CodingSizeUAString(dv.NameSpaceUri);
-        sum += mem.CodingSize(dv.UnitId);
-        sum += mem.CodingSize(dv.DisplayName);
-        sum += mem.CodingSize(dv.Description);
+        sum += Coding.CodingSizeUAString(dv.NameSpaceUri);
+        sum += Coding.CodingSize(dv.UnitId);
+        sum += Coding.CodingSize(dv.DisplayName);
+        sum += Coding.CodingSize(dv.Description);
 
         return sum;
     }

--- a/NET Core/LibUA/ValueTypes/OpcRange.cs
+++ b/NET Core/LibUA/ValueTypes/OpcRange.cs
@@ -14,8 +14,8 @@ public static class RangeExtensions
     {
         int sum = 0;
 
-        sum += mem.CodingSize(dv.Low);
-        sum += mem.CodingSize(dv.High);
+        sum += Coding.CodingSize(dv.Low);
+        sum += Coding.CodingSize(dv.High);
 
         return sum;
     }

--- a/NET/LibUA/AddressSpace.cs
+++ b/NET/LibUA/AddressSpace.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LibUA
 {

--- a/NET/LibUA/Application.cs
+++ b/NET/LibUA/Application.cs
@@ -5,9 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using LibUA.Core;
 
 namespace LibUA

--- a/NET/LibUA/Coding.cs
+++ b/NET/LibUA/Coding.cs
@@ -1,0 +1,344 @@
+﻿using System;
+using System.Text;
+
+namespace LibUA
+{
+    namespace Core
+    {
+        public class Coding
+        {
+            public static int CodingSize(byte v) { return 1; }
+            public static int CodingSize(SByte v) { return 1; }
+            public static int CodingSize(bool v) { return 1; }
+            public static int CodingSize(Int16 v) { return 2; }
+            public static int CodingSize(UInt16 v) { return 2; }
+            public static int CodingSize(Int32 v) { return 4; }
+            public static int CodingSize(UInt32 v) { return 4; }
+            public static int CodingSize(Int64 v) { return 8; }
+            public static int CodingSize(UInt64 v) { return 8; }
+            public static int CodingSize(Single v) { return 4; }
+            public static int CodingSize(Double v) { return 8; }
+            public static int CodingSize(string s) { return CodingSize((int)s.Length) + s.Length; }
+            public static int CodingSize(NodeId id)
+            {
+                switch (id.IdType)
+                {
+                    case NodeIdNetType.Numeric:
+                        {
+                            if (id.NamespaceIndex == 0 && id.NumericIdentifier <= 0xFF)
+                            {
+                                return 2;
+                            }
+                            else if (id.NamespaceIndex <= 0xFF && id.NumericIdentifier <= 0xFFFF)
+                            {
+                                return 4;
+                            }
+                            else
+                            {
+                                return 7;
+                            }
+                        }
+
+                    case NodeIdNetType.String:
+                        {
+                            return 3 + Coding.CodingSizeUAString(id.StringIdentifier);
+                        }
+
+                    default:
+                        // TODO: Handle
+                        throw new Exception();
+                }
+            }
+            public static int CodingSize(QualifiedName qn)
+            {
+                return Coding.CodingSize(qn.NamespaceIndex) + Coding.CodingSizeUAString(qn.Name);
+            }
+            public static int CodingSize(LocalizedText ad)
+            {
+                int size = Coding.CodingSize((byte)0);
+                if (!string.IsNullOrEmpty(ad.Locale)) { size += Coding.CodingSizeUAString(ad.Locale); }
+                if (!string.IsNullOrEmpty(ad.Text)) { size += Coding.CodingSizeUAString(ad.Text); }
+
+                return size;
+            }
+            public static int CodingSize(ExtensionObject obj)
+            {
+                int size = 0;
+
+                if (obj == null)
+                {
+                    size = Coding.CodingSize(NodeId.Zero);
+                    size += Coding.CodingSize((byte)ExtensionObjectBodyType.None);
+                    return size;
+                }
+
+                size += Coding.CodingSize(obj.TypeId);
+                size += Coding.CodingSize((byte)ExtensionObjectBodyType.None);
+
+                if (obj.Body == null)
+                {
+                    return size;
+                }
+
+                size += Coding.CodingSizeUAByteString(obj.Body);
+
+                return size;
+            }
+            public static int CodingSizeUAByteString(byte[] str)
+            {
+                if (str == null) { return Coding.CodingSize((UInt32)0); }
+
+                return Coding.CodingSize((UInt32)0) + str.Length;
+            }
+            public static int CodingSizeUAGuidByteString(byte[] str)
+            {
+                if (str == null) { return 0; }
+
+                return str.Length;
+            }
+            public static int CodingSizeUAString(string str)
+            {
+                if (str == null) { return Coding.CodingSize((UInt32)0); }
+
+                return Coding.CodingSize((UInt32)0) + Encoding.UTF8.GetBytes(str).Length;
+            }
+
+            public static Type GetNetType(VariantType type)
+            {
+                if (type == VariantType.Boolean) { return typeof(bool); }
+                if (type == VariantType.SByte) { return typeof(SByte); }
+                if (type == VariantType.Byte) { return typeof(Byte); }
+                if (type == VariantType.Int16) { return typeof(Int16); }
+                if (type == VariantType.UInt16) { return typeof(UInt16); }
+                if (type == VariantType.Int32) { return typeof(Int32); }
+                if (type == VariantType.UInt32) { return typeof(UInt32); }
+                if (type == VariantType.Int64) { return typeof(Int64); }
+                if (type == VariantType.UInt64) { return typeof(UInt64); }
+                if (type == VariantType.Float) { return typeof(float); }
+                if (type == VariantType.Double) { return typeof(Double); }
+                if (type == VariantType.NodeId) { return typeof(NodeId); }
+                if (type == VariantType.QualifiedName) { return typeof(QualifiedName); }
+                if (type == VariantType.LocalizedText) { return typeof(LocalizedText); }
+                if (type == VariantType.String) { return typeof(String); }
+                if (type == VariantType.ExtensionObject) { return typeof(ExtensionObject); }
+
+                // TODO: Other types
+
+                return null;
+            }
+
+
+            public static VariantType GetVariantTypeFromInstance(object obj)
+            {
+                if (obj is bool) { return VariantType.Boolean; }
+                if (obj is SByte) { return VariantType.SByte; }
+                if (obj is Byte) { return VariantType.Byte; }
+                if (obj is Int16) { return VariantType.Int16; }
+                if (obj is UInt16) { return VariantType.UInt16; }
+                if (obj is Int32) { return VariantType.Int32; }
+                if (obj is UInt32) { return VariantType.UInt32; }
+                if (obj is Int64) { return VariantType.Int64; }
+                if (obj is UInt64) { return VariantType.UInt64; }
+                if (obj is float) { return VariantType.Float; }
+                if (obj is Double) { return VariantType.Double; }
+                if (obj is string) { return VariantType.String; }
+                if (obj is byte[]) { return VariantType.ByteString; }
+                if (obj is NodeId) { return VariantType.NodeId; }
+                if (obj is QualifiedName) { return VariantType.QualifiedName; }
+                if (obj is LocalizedText) { return VariantType.LocalizedText; }
+                if (obj is DateTime) { return VariantType.DateTime; }
+                if (obj is StatusCode) { return VariantType.StatusCode; }
+                if (obj is ExtensionObject) { return VariantType.ExtensionObject; }
+
+                // TODO: Other types
+
+                return VariantType.Null;
+            }
+
+            public static VariantType GetVariantTypeFromType(Type type)
+            {
+                if (type == typeof(bool)) { return VariantType.Boolean; }
+                if (type == typeof(SByte)) { return VariantType.SByte; }
+                if (type == typeof(Byte)) { return VariantType.Byte; }
+                if (type == typeof(Int16)) { return VariantType.Int16; }
+                if (type == typeof(UInt16)) { return VariantType.UInt16; }
+                if (type == typeof(Int32)) { return VariantType.Int32; }
+                if (type == typeof(UInt32)) { return VariantType.UInt32; }
+                if (type == typeof(Int64)) { return VariantType.Int64; }
+                if (type == typeof(UInt64)) { return VariantType.UInt64; }
+                if (type == typeof(float)) { return VariantType.Float; }
+                if (type == typeof(Double)) { return VariantType.Double; }
+                if (type == typeof(string)) { return VariantType.String; }
+                if (type == typeof(byte[])) { return VariantType.ByteString; }
+                if (type == typeof(NodeId)) { return VariantType.NodeId; }
+                if (type == typeof(QualifiedName)) { return VariantType.QualifiedName; }
+                if (type == typeof(LocalizedText)) { return VariantType.LocalizedText; }
+                if (type == typeof(DateTime)) { return VariantType.DateTime; }
+                if (type == typeof(StatusCode)) { return VariantType.StatusCode; }
+                if (type == typeof(ExtensionObject)) { return VariantType.ExtensionObject; }
+
+                // TODO: Other types
+
+                return VariantType.Null;
+            }
+
+            public static int VariantCodingSize(object obj)
+            {
+                int rank = 0;
+                VariantType varType;
+                if (obj is Array && !(obj is byte[]))
+                {
+                    var type = obj.GetType();
+                    rank = type.GetArrayRank();
+                    type = type.GetElementType();
+
+                    varType = GetVariantTypeFromType(type);
+                }
+                else
+                {
+                    varType = GetVariantTypeFromInstance(obj);
+                }
+
+                int size = 0;
+
+                byte mask = (byte)varType;
+                ++size;
+
+                if (rank > 1)
+                {
+                    mask |= 0x40;
+                }
+
+                if (rank >= 1)
+                {
+                    mask |= 0x80;
+                    size += CodingSize((int)((Array)obj).Length);
+
+                    foreach (var value in obj as Array)
+                    {
+                        size += VariantCodingSize(value, mask);
+                    }
+
+                    if (rank > 1)
+                    {
+                        size += CodingSize((int)rank) * (1 + rank);
+                    }
+                }
+                else
+                {
+                    size += VariantCodingSize(obj, mask);
+                }
+
+                return size;
+            }
+
+            public static int VarLenU32Decode(out UInt32 v, byte[] Src)
+            {
+                v = 0;
+
+                for (int i = 0, n = 0; i < 5; i++, n += 7)
+                {
+                    int curLen = 1 + i;
+                    if (Src.Length < curLen)
+                    {
+                        return -1;
+                    }
+
+                    v |= (uint)(((byte)(Src[i] >> 1) & 0x7F) << n);
+                    if ((Src[i] & 1) != 0)
+                    {
+                        continue;
+                    }
+
+                    return curLen;
+                }
+
+                return 0;
+            }
+
+            public static int VarLenU32Encode(UInt32 v, byte[] Dest)
+            {
+                for (int i = 0, n = 0; i < 5; i++, n += 7)
+                {
+                    if (i == 4 && (v >> n) > 0x7F)
+                    {
+                        // Overflow
+                        break;
+                    }
+
+                    Dest[i] = (byte)(((v >> n) & 0x7F) << 1);
+                    if ((v >> n) < 0x80)
+                    {
+                        return i + 1;
+                    }
+
+                    Dest[i] |= 1;
+                }
+
+                // Overflow
+                return 0;
+            }
+
+            public static int VarLenU32Size(UInt32 v)
+            {
+                for (int i = 0, n = 0; i < 5; i++, n += 7)
+                {
+                    if (i == 4 && (v >> n) > 0x7F)
+                    {
+                        // Overflow
+                        break;
+                    }
+
+                    if ((v >> n) < 0x80)
+                    {
+                        return i + 1;
+                    }
+                }
+
+                // Overflow
+                return 0;
+            }
+
+            private static int VariantCodingSize(object obj, byte mask)
+            {
+                int size = 0;
+
+                switch (mask & 0x3F)
+                {
+                    case (int)VariantType.Null: break;
+                    case (int)VariantType.Boolean: size += CodingSize((bool)obj); break;
+                    case (int)VariantType.SByte: size += CodingSize((SByte)obj); break;
+                    case (int)VariantType.Byte: size += CodingSize((Byte)obj); break;
+                    case (int)VariantType.Int16: size += CodingSize((Int16)obj); break;
+                    case (int)VariantType.UInt16: size += CodingSize((UInt16)obj); break;
+                    case (int)VariantType.Int32: size += CodingSize((Int32)obj); break;
+                    case (int)VariantType.UInt32: size += CodingSize((UInt32)obj); break;
+                    case (int)VariantType.Int64: size += CodingSize((Int64)obj); break;
+                    case (int)VariantType.UInt64: size += CodingSize((UInt64)obj); break;
+                    case (int)VariantType.Float: size += CodingSize((Single)obj); break;
+                    case (int)VariantType.Double: size += CodingSize((Double)obj); break;
+                    case (int)VariantType.String: size += CodingSizeUAString((string)obj); break;
+                    case (int)VariantType.DateTime: size += CodingSize((Int64)0); break;
+                    //case (int)VariantType.Guid: size += CodingSize((int)obj); break;
+                    case (int)VariantType.ByteString: size += CodingSizeUAByteString((byte[])obj); break;
+                    //case (int)VariantType.XmlElement: size += CodingSize((int)obj); break;
+                    case (int)VariantType.NodeId: size += CodingSize((NodeId)obj); break;
+                    //case (int)VariantType.ExpandedNodeId: size += CodingSize((int)obj); break;
+                    case (int)VariantType.StatusCode: size += CodingSize((UInt32)obj); break;
+                    case (int)VariantType.QualifiedName: size += CodingSize((QualifiedName)obj); break;
+                    case (int)VariantType.LocalizedText: size += CodingSize((LocalizedText)obj); break;
+                    case (int)VariantType.ExtensionObject: size += CodingSize((ExtensionObject)obj); break;
+                    //case (int)VariantType.DataValue: size += CodingSize((int)obj); break;
+                    //case (int)VariantType.Variant: size += CodingSize((int)obj); break;
+                    //case (int)VariantType.DiagnosticInfo: size += CodingSize((int)obj); break;
+                    default:
+                        throw new Exception("TODO");
+                }
+
+                return size;
+            }
+        }
+    }
+}
+
+

--- a/NET/LibUA/LibUA.csproj
+++ b/NET/LibUA/LibUA.csproj
@@ -50,8 +50,9 @@
     <Compile Include="AddressSpace.cs" />
     <Compile Include="Application.cs" />
     <Compile Include="Client.cs" />
-    <Compile Include="Encoding.cs" />
+    <Compile Include="Coding.cs" />
     <Compile Include="ILogger.cs" />
+    <Compile Include="MemoryBuffer.cs" />
     <Compile Include="MemoryBufferExtensions.cs" />
     <Compile Include="NetDispatcher.cs" />
     <Compile Include="Security.Cryptography\AesCng.cs" />

--- a/NET/LibUA/MemoryBuffer.cs
+++ b/NET/LibUA/MemoryBuffer.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LibUA
 {
     namespace Core
     {
-        public class MemoryBuffer : IDisposable
+        public class MemoryBuffer
         {
             public bool IsReadOnly { get; protected set; }
 
@@ -102,46 +97,14 @@ namespace LibUA
                 }
             }
 
-            private bool isRented;
             public MemoryBuffer(int Size)
             {
                 Position = 0;
                 IsReadOnly = false;
                 IsFixedCapacity = true;
 
-                Buffer = ArrayPool<byte>.Shared.Rent(Size);
+                Buffer = new byte[Size];
                 Capacity = Allocated = Size;
-                isRented = true;
-            }
-
-            private bool disposed;
-
-            public void Dispose()
-            {
-                if (!isRented)
-                    return;
-
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
-
-            protected virtual void Dispose(bool disposing)
-            {
-                if (!disposed)
-                {
-                    if (disposing)
-                    {
-                        // Return the array back to the pool
-                        ArrayPool<byte>.Shared.Return(Buffer);
-                    }
-
-                    disposed = true;
-                }
-            }
-
-            ~MemoryBuffer()
-            {
-                Dispose(false);
             }
 
             public bool EnsureAvailable(int Length, bool readOnly)
@@ -575,87 +538,6 @@ namespace LibUA
                 return true;
             }
 
-            public int CodingSize(byte v) { return 1; }
-            public int CodingSize(SByte v) { return 1; }
-            public int CodingSize(bool v) { return 1; }
-            public int CodingSize(Int16 v) { return 2; }
-            public int CodingSize(UInt16 v) { return 2; }
-            public int CodingSize(Int32 v) { return 4; }
-            public int CodingSize(UInt32 v) { return 4; }
-            public int CodingSize(Int64 v) { return 8; }
-            public int CodingSize(UInt64 v) { return 8; }
-            public int CodingSize(Single v) { return 4; }
-            public int CodingSize(Double v) { return 8; }
-
-            public int CodingSize(string s) { return CodingSize((int)s.Length) + s.Length; }
-
-            public static int VarLenU32Decode(out UInt32 v, byte[] Src)
-            {
-                v = 0;
-
-                for (int i = 0, n = 0; i < 5; i++, n += 7)
-                {
-                    int curLen = 1 + i;
-                    if (Src.Length < curLen)
-                    {
-                        return -1;
-                    }
-
-                    v |= (uint)(((byte)(Src[i] >> 1) & 0x7F) << n);
-                    if ((Src[i] & 1) != 0)
-                    {
-                        continue;
-                    }
-
-                    return curLen;
-                }
-
-                return 0;
-            }
-
-            public static int VarLenU32Encode(UInt32 v, byte[] Dest)
-            {
-                for (int i = 0, n = 0; i < 5; i++, n += 7)
-                {
-                    if (i == 4 && (v >> n) > 0x7F)
-                    {
-                        // Overflow
-                        break;
-                    }
-
-                    Dest[i] = (byte)(((v >> n) & 0x7F) << 1);
-                    if ((v >> n) < 0x80)
-                    {
-                        return i + 1;
-                    }
-
-                    Dest[i] |= 1;
-                }
-
-                // Overflow
-                return 0;
-            }
-
-            public static int VarLenU32Size(UInt32 v)
-            {
-                for (int i = 0, n = 0; i < 5; i++, n += 7)
-                {
-                    if (i == 4 && (v >> n) > 0x7F)
-                    {
-                        // Overflow
-                        break;
-                    }
-
-                    if ((v >> n) < 0x80)
-                    {
-                        return i + 1;
-                    }
-                }
-
-                // Overflow
-                return 0;
-            }
-
             public int VarLenU32Decode(out UInt32 v)
             {
                 int len = Capacity - Position;
@@ -668,7 +550,7 @@ namespace LibUA
                     Array.Copy(Buffer, Position, tmp, 0, bufLen);
                 }
 
-                int adv = VarLenU32Decode(out v, tmp);
+                int adv = Coding.VarLenU32Decode(out v, tmp);
                 if (adv > 0)
                 {
                     Position += adv;
@@ -681,142 +563,13 @@ namespace LibUA
             {
                 var buffer = new byte[8];
 
-                int adv = VarLenU32Encode(v, buffer);
+                int adv = Coding.VarLenU32Encode(v, buffer);
                 if (adv > 0)
                 {
                     Append(buffer, adv);
                 }
 
                 return adv;
-            }
-
-            public static VariantType GetVariantTypeFromType(Type type)
-            {
-                if (type == typeof(bool)) { return VariantType.Boolean; }
-                if (type == typeof(SByte)) { return VariantType.SByte; }
-                if (type == typeof(Byte)) { return VariantType.Byte; }
-                if (type == typeof(Int16)) { return VariantType.Int16; }
-                if (type == typeof(UInt16)) { return VariantType.UInt16; }
-                if (type == typeof(Int32)) { return VariantType.Int32; }
-                if (type == typeof(UInt32)) { return VariantType.UInt32; }
-                if (type == typeof(Int64)) { return VariantType.Int64; }
-                if (type == typeof(UInt64)) { return VariantType.UInt64; }
-                if (type == typeof(float)) { return VariantType.Float; }
-                if (type == typeof(Double)) { return VariantType.Double; }
-                if (type == typeof(string)) { return VariantType.String; }
-                if (type == typeof(byte[])) { return VariantType.ByteString; }
-                if (type == typeof(NodeId)) { return VariantType.NodeId; }
-                if (type == typeof(QualifiedName)) { return VariantType.QualifiedName; }
-                if (type == typeof(LocalizedText)) { return VariantType.LocalizedText; }
-                if (type == typeof(DateTime)) { return VariantType.DateTime; }
-                if (type == typeof(StatusCode)) { return VariantType.StatusCode; }
-                if (type == typeof(ExtensionObject)) { return VariantType.ExtensionObject; }
-
-                // TODO: Other types
-
-                return VariantType.Null;
-            }
-
-
-            public static VariantType GetVariantTypeFromInstance(object obj)
-            {
-                if (obj is bool) { return VariantType.Boolean; }
-                if (obj is SByte) { return VariantType.SByte; }
-                if (obj is Byte) { return VariantType.Byte; }
-                if (obj is Int16) { return VariantType.Int16; }
-                if (obj is UInt16) { return VariantType.UInt16; }
-                if (obj is Int32) { return VariantType.Int32; }
-                if (obj is UInt32) { return VariantType.UInt32; }
-                if (obj is Int64) { return VariantType.Int64; }
-                if (obj is UInt64) { return VariantType.UInt64; }
-                if (obj is float) { return VariantType.Float; }
-                if (obj is Double) { return VariantType.Double; }
-                if (obj is string) { return VariantType.String; }
-                if (obj is byte[]) { return VariantType.ByteString; }
-                if (obj is NodeId) { return VariantType.NodeId; }
-                if (obj is QualifiedName) { return VariantType.QualifiedName; }
-                if (obj is LocalizedText) { return VariantType.LocalizedText; }
-                if (obj is DateTime) { return VariantType.DateTime; }
-                if (obj is StatusCode) { return VariantType.StatusCode; }
-                if (obj is ExtensionObject) { return VariantType.ExtensionObject; }
-
-                // TODO: Other types
-
-                return VariantType.Null;
-            }
-
-            public static Type GetNetType(VariantType type)
-            {
-                if (type == VariantType.Boolean) { return typeof(bool); }
-                if (type == VariantType.SByte) { return typeof(SByte); }
-                if (type == VariantType.Byte) { return typeof(Byte); }
-                if (type == VariantType.Int16) { return typeof(Int16); }
-                if (type == VariantType.UInt16) { return typeof(UInt16); }
-                if (type == VariantType.Int32) { return typeof(Int32); }
-                if (type == VariantType.UInt32) { return typeof(UInt32); }
-                if (type == VariantType.Int64) { return typeof(Int64); }
-                if (type == VariantType.UInt64) { return typeof(UInt64); }
-                if (type == VariantType.Float) { return typeof(float); }
-                if (type == VariantType.Double) { return typeof(Double); }
-                if (type == VariantType.NodeId) { return typeof(NodeId); }
-                if (type == VariantType.QualifiedName) { return typeof(QualifiedName); }
-                if (type == VariantType.LocalizedText) { return typeof(LocalizedText); }
-                if (type == VariantType.String) { return typeof(String); }
-                if (type == VariantType.ExtensionObject) { return typeof(ExtensionObject); }
-
-                // TODO: Other types
-
-                return null;
-            }
-
-            public int VariantCodingSize(object obj)
-            {
-                int rank = 0;
-                VariantType varType;
-                if (obj is Array && !(obj is byte[]))
-                {
-                    var type = obj.GetType();
-                    rank = type.GetArrayRank();
-                    type = type.GetElementType();
-
-                    varType = GetVariantTypeFromType(type);
-                }
-                else
-                {
-                    varType = GetVariantTypeFromInstance(obj);
-                }
-
-                int size = 0;
-
-                byte mask = (byte)varType;
-                ++size;
-
-                if (rank > 1)
-                {
-                    mask |= 0x40;
-                }
-
-                if (rank >= 1)
-                {
-                    mask |= 0x80;
-                    size += CodingSize((int)((Array)obj).Length);
-
-                    foreach (var value in obj as Array)
-                    {
-                        size += VariantCodingSize(value, mask);
-                    }
-
-                    if (rank > 1)
-                    {
-                        size += CodingSize((int)rank) * (1 + rank);
-                    }
-                }
-                else
-                {
-                    size += VariantCodingSize(obj, mask);
-                }
-
-                return size;
             }
 
             public bool VariantEncode(object obj)
@@ -829,11 +582,11 @@ namespace LibUA
                     rank = type.GetArrayRank();
                     type = type.GetElementType();
 
-                    varType = GetVariantTypeFromType(type);
+                    varType = Coding.GetVariantTypeFromType(type);
                 }
                 else
                 {
-                    varType = GetVariantTypeFromInstance(obj);
+                    varType = Coding.GetVariantTypeFromInstance(obj);
                 }
 
                 byte mask = (byte)varType;
@@ -894,7 +647,8 @@ namespace LibUA
                 {
                     if (!Decode(out int arrLen)) { return false; }
                     if (arrLen < 0) { return false; }
-                    Type type = GetNetType((VariantType)(mask & 0x3F));
+
+                    Type type = Coding.GetNetType((VariantType)(mask & 0x3F));
 
                     var arr = Array.CreateInstance(type, arrLen);
                     for (int i = 0; i < arrLen; i++)
@@ -929,45 +683,6 @@ namespace LibUA
                 }
 
                 return true;
-            }
-
-            private int VariantCodingSize(object obj, byte mask)
-            {
-                int size = 0;
-
-                switch (mask & 0x3F)
-                {
-                    case (int)VariantType.Null: break;
-                    case (int)VariantType.Boolean: size += CodingSize((bool)obj); break;
-                    case (int)VariantType.SByte: size += CodingSize((SByte)obj); break;
-                    case (int)VariantType.Byte: size += CodingSize((Byte)obj); break;
-                    case (int)VariantType.Int16: size += CodingSize((Int16)obj); break;
-                    case (int)VariantType.UInt16: size += CodingSize((UInt16)obj); break;
-                    case (int)VariantType.Int32: size += CodingSize((Int32)obj); break;
-                    case (int)VariantType.UInt32: size += CodingSize((UInt32)obj); break;
-                    case (int)VariantType.Int64: size += CodingSize((Int64)obj); break;
-                    case (int)VariantType.UInt64: size += CodingSize((UInt64)obj); break;
-                    case (int)VariantType.Float: size += CodingSize((Single)obj); break;
-                    case (int)VariantType.Double: size += CodingSize((Double)obj); break;
-                    case (int)VariantType.String: size += this.CodingSizeUAString((string)obj); break;
-                    case (int)VariantType.DateTime: size += CodingSize((Int64)0); break;
-                    //case (int)VariantType.Guid: size += CodingSize((int)obj); break;
-                    case (int)VariantType.ByteString: size += this.CodingSizeUAByteString((byte[])obj); break;
-                    //case (int)VariantType.XmlElement: size += CodingSize((int)obj); break;
-                    case (int)VariantType.NodeId: size += this.CodingSize((NodeId)obj); break;
-                    //case (int)VariantType.ExpandedNodeId: size += CodingSize((int)obj); break;
-                    case (int)VariantType.StatusCode: size += CodingSize((UInt32)obj); break;
-                    case (int)VariantType.QualifiedName: size += this.CodingSize((QualifiedName)obj); break;
-                    case (int)VariantType.LocalizedText: size += this.CodingSize((LocalizedText)obj); break;
-                    case (int)VariantType.ExtensionObject: size += this.CodingSize((ExtensionObject)obj); break;
-                    //case (int)VariantType.DataValue: size += CodingSize((int)obj); break;
-                    //case (int)VariantType.Variant: size += CodingSize((int)obj); break;
-                    //case (int)VariantType.DiagnosticInfo: size += CodingSize((int)obj); break;
-                    default:
-                        throw new Exception("TODO");
-                }
-
-                return size;
             }
 
             public bool VariantEncode(object obj, byte mask)

--- a/NET/LibUA/MemoryBufferExtensions.cs
+++ b/NET/LibUA/MemoryBufferExtensions.cs
@@ -341,7 +341,7 @@ namespace LibUA
             {
                 NodeId typeId = new NodeId(597);
                 byte encodingMask = 1;
-                UInt32 eoSize = (UInt32)mem.VariantCodingSize((cfe.Operands[i] as LiteralOperand).Value);
+                UInt32 eoSize = (UInt32)Coding.VariantCodingSize((cfe.Operands[i] as LiteralOperand).Value);
 
                 if (!mem.Encode(typeId)) { return false; }
                 if (!mem.Encode(encodingMask)) { return false; }
@@ -820,25 +820,25 @@ namespace LibUA
         {
             int sum = 0;
 
-            sum += mem.CodingSize(dv.GetEncodingMask());
+            sum += Coding.CodingSize(dv.GetEncodingMask());
             if (dv.Value != null)
             {
-                sum += mem.VariantCodingSize(dv.Value);
+                sum += Coding.VariantCodingSize(dv.Value);
             }
 
             if (dv.StatusCode.HasValue)
             {
-                sum += mem.CodingSize((UInt32)dv.StatusCode.Value);
+                sum += Coding.CodingSize((UInt32)dv.StatusCode.Value);
             }
 
             if (dv.SourceTimestamp.HasValue)
             {
-                sum += mem.CodingSize(dv.SourceTimestamp.Value.ToFileTimeUtc());
+                sum += Coding.CodingSize(dv.SourceTimestamp.Value.ToFileTimeUtc());
             }
 
             if (dv.ServerTimestamp.HasValue)
             {
-                sum += mem.CodingSize(dv.ServerTimestamp.Value.ToFileTimeUtc());
+                sum += Coding.CodingSize(dv.ServerTimestamp.Value.ToFileTimeUtc());
             }
 
             return sum;
@@ -1049,7 +1049,7 @@ namespace LibUA
 
         public static int CodingSize(this MemoryBuffer mem, QualifiedName qn)
         {
-            return mem.CodingSize(qn.NamespaceIndex) + mem.CodingSizeUAString(qn.Name);
+            return Coding.CodingSize(qn.NamespaceIndex) + Coding.CodingSizeUAString(qn.Name);
         }
 
         public static bool Encode(this MemoryBuffer mem, QualifiedName qn)
@@ -1084,9 +1084,9 @@ namespace LibUA
 
         public static int CodingSize(this MemoryBuffer mem, LocalizedText ad)
         {
-            int size = mem.CodingSize((byte)0);
-            if (!string.IsNullOrEmpty(ad.Locale)) { size += mem.CodingSizeUAString(ad.Locale); }
-            if (!string.IsNullOrEmpty(ad.Text)) { size += mem.CodingSizeUAString(ad.Text); }
+            int size = Coding.CodingSize((byte)0);
+            if (!string.IsNullOrEmpty(ad.Locale)) { size += Coding.CodingSizeUAString(ad.Locale); }
+            if (!string.IsNullOrEmpty(ad.Text)) { size += Coding.CodingSizeUAString(ad.Text); }
 
             return size;
         }
@@ -1190,20 +1190,20 @@ namespace LibUA
 
             if (obj == null)
             {
-                size = mem.CodingSize(NodeId.Zero);
-                size += mem.CodingSize((byte)ExtensionObjectBodyType.None);
+                size = Coding.CodingSize(NodeId.Zero);
+                size += Coding.CodingSize((byte)ExtensionObjectBodyType.None);
                 return size;
             }
 
-            size += mem.CodingSize(obj.TypeId);
-            size += mem.CodingSize((byte)ExtensionObjectBodyType.None);
+            size += Coding.CodingSize(obj.TypeId);
+            size += Coding.CodingSize((byte)ExtensionObjectBodyType.None);
 
             if (obj.Body == null)
             {
                 return size;
             }
 
-            size += mem.CodingSizeUAByteString(obj.Body);
+            size += Coding.CodingSizeUAByteString(obj.Body);
 
             return size;
         }
@@ -1401,36 +1401,6 @@ namespace LibUA
             return true;
         }
 
-        public static int CodingSize(this MemoryBuffer mem, NodeId id)
-        {
-            switch (id.IdType)
-            {
-                case NodeIdNetType.Numeric:
-                    {
-                        if (id.NamespaceIndex == 0 && id.NumericIdentifier <= 0xFF)
-                        {
-                            return 2;
-                        }
-                        else if (id.NamespaceIndex <= 0xFF && id.NumericIdentifier <= 0xFFFF)
-                        {
-                            return 4;
-                        }
-                        else
-                        {
-                            return 7;
-                        }
-                    }
-
-                case NodeIdNetType.String:
-                    {
-                        return 3 + mem.CodingSizeUAString(id.StringIdentifier);
-                    }
-
-                default:
-                    // TODO: Handle
-                    throw new Exception();
-            }
-        }
 
         public static bool EncodeUAByteString(this MemoryBuffer mem, byte[] str)
         {
@@ -1546,26 +1516,7 @@ namespace LibUA
             return true;
         }
 
-        public static int CodingSizeUAByteString(this MemoryBuffer mem, byte[] str)
-        {
-            if (str == null) { return mem.CodingSize((UInt32)0); }
 
-            return mem.CodingSize((UInt32)0) + str.Length;
-        }
-
-        public static int CodingSizeUAGuidByteString(this MemoryBuffer mem, byte[] str)
-        {
-            if (str == null) { return 0; }
-
-            return str.Length;
-        }
-
-        public static int CodingSizeUAString(this MemoryBuffer mem, string str)
-        {
-            if (str == null) { return mem.CodingSize((UInt32)0); }
-
-            return mem.CodingSize((UInt32)0) + Encoding.UTF8.GetBytes(str).Length;
-        }
 
         public static bool EncodeUAString(this MemoryBuffer mem, string str)
         {

--- a/NET/LibUA/NetDispatcher.cs
+++ b/NET/LibUA/NetDispatcher.cs
@@ -134,7 +134,7 @@ namespace LibUA
                         int sizeRequired = 4 + 4;
                         for (int i = 0; i < fields.Length; i++)
                         {
-                            sizeRequired += respBuf.VariantCodingSize(fields[i]);
+                            sizeRequired += Coding.VariantCodingSize(fields[i]);
                         }
 
                         // ClientHandle + numEventFields + ev
@@ -2038,7 +2038,7 @@ namespace LibUA
                                 int sizeRequired = 4;
                                 for (int k = 0; k < resultsEvents[j].Length; k++)
                                 {
-                                    sizeRequired += respBuf.VariantCodingSize(resultsEvents[j][k]);
+                                    sizeRequired += Coding.VariantCodingSize(resultsEvents[j][k]);
                                 }
 
                                 if (availableSpace < sizeRequired)

--- a/NET/LibUA/Security.cs
+++ b/NET/LibUA/Security.cs
@@ -5,7 +5,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using LibUA.Core;
-using LibUA.Security.Cryptography;
 using RSACng = LibUA.Security.Cryptography.RSACng;
 
 namespace LibUA

--- a/NET/LibUA/Server.cs
+++ b/NET/LibUA/Server.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using LibUA.Core;
 
 namespace LibUA

--- a/NET/LibUA/Types.cs
+++ b/NET/LibUA/Types.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LibUA
 {


### PR DESCRIPTION
Change CodingSize type methods to Static, some were previously configured as Extension methods.
Since there were so many, split them off into their own class ("Coding"). The naming of "Encoding.cs" file seemed 'off' when it mostly consisted of the MemoryBuffer class also, so renamed this file to 'MemoryBuffer.cs'.
Since it was already a change of these two files, I also tidied up the 'using's for the project (just with Visual Studio quick suggestion)

(Also removed SubArray and Memset from .NET Framework version to align with .NET Core)