### PR TITLE
[DRAFT] Migrate from raw sockets to streams

### DIFF
--- a/NET Core/LibUA/NetDispatcher.cs
+++ b/NET Core/LibUA/NetDispatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
@@ -22,8 +23,8 @@ namespace LibUA
                 return string.Format("{0}:{1}", config.Endpoint.ToString(), config.Session.ToString());
             }
 
-            public NetDispatcher(Master server, Application app, Socket socket, ILogger logger)
-                : base(server, app, socket, logger)
+            public NetDispatcher(Master server, Application app, Stream stream, ILogger logger)
+                : base(server, app, stream, logger)
             {
                 // Initialize then start consumer
                 thread.Start(this);
@@ -1303,7 +1304,7 @@ namespace LibUA
                             }
                         }
 
-                        _ = socket.Send(chunk.Buffer, chunk.Position, SocketFlags.None);
+                        stream.Write(chunk.Buffer, 0, chunk.Position);
                     }
 
                     //var chunkSizes = ChunkCalculateSizes(bigChunkBuffer);
@@ -1337,7 +1338,7 @@ namespace LibUA
                         }
                     }
 
-                    _ = socket.Send(respBuf.Buffer, respBuf.Position, SocketFlags.None);
+                    stream.Write(respBuf.Buffer, 0, respBuf.Position);
                 }
             }
 
@@ -1710,7 +1711,7 @@ namespace LibUA
 
                 config.LocalSequence.SequenceNumber++;
 
-                socket.Send(respBuf.Buffer, respBuf.Position, SocketFlags.None);
+                stream.Write(respBuf.Buffer, 0, respBuf.Position);
                 return (int)messageSize;
             }
 
@@ -1785,7 +1786,7 @@ namespace LibUA
 
                 MarkPositionAsSize(respBuf);
 
-                socket.Send(respBuf.Buffer, respBuf.Position, SocketFlags.None);
+                stream.Write(respBuf.Buffer, 0, respBuf.Position);
                 return (int)messageSize;
             }
 

--- a/NET Core/LibUA/NetDispatcherBase.cs
+++ b/NET Core/LibUA/NetDispatcherBase.cs
@@ -1,0 +1,377 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using LibUA.Core;
+using Microsoft.Extensions.Logging;
+
+namespace LibUA
+{
+    namespace Server
+    {
+        public class NetDispatcherBase
+        {
+            public const int MaxContinuationPoints = 256;
+            public const int MaxPublishRequests = 1024;
+            public const int MaxMonitoredPerSubscription = 65536;
+            public const int MaxTokenLifetime = 600 * 1000;
+            public const uint MaxBrowseResults = 10000;
+            public const uint MaxHistoryReadNodes = 256;
+            public const uint MaxSubscriptionAcknowledgementsPerPublish = 16;
+
+            // Message type, message size, secure channel ID, security token ID
+            public const int MessageEncodedBlockStart = 16;
+            public const int ChunkHeaderOverhead = 4 * 6;
+
+            public const double UsableMessageSizeFactor = 0.8;
+            public const int TLPaddingOverhead = 1024;
+            private uint uaStatusCode = 0;
+            public uint UAStatusCode
+            {
+                get { return uaStatusCode; }
+                protected set { uaStatusCode = value; }
+            }
+
+            protected const int ErrorInternal = -1;
+            protected const int ErrorParseFail = -2;
+            protected const int ErrorRespWrite = -3;
+            protected const int ErrorClosed = -4;
+
+            public const int PulseInterval = 100;
+
+            protected Application app = null;
+            protected ILogger logger = null;
+            private readonly Master server = null;
+            protected Stream stream = null;
+            protected int maximumMessageSize;
+
+            // Ensure publishes are in sequence and not in parallel
+            private readonly object csDispatching = new object();
+
+            protected Thread thread = null;
+            protected bool threadAbort = false;
+
+            protected SLChannel config = null;
+
+            protected UInt32 nextSubscriptionID = 1;
+            protected Queue<RequestHeader> pendingNotificationRequests = null;
+            protected Dictionary<uint, Queue<uint>> pendingSubscriptionAcknowledgements = null;
+            //protected Dictionary<uint, Application.MonitorDispatcherConfiguration> monitorMap = null;
+            //protected List<Application.MonitorDispatcherConfiguration> monitorList = null;
+
+            protected Dictionary<UInt32, Subscription> subscriptionMap = null;
+
+            protected Stack<int> availableContinuationPoints = null;
+            protected Dictionary<int, ContinuationPointBrowse> continuationBrowse = null;
+            protected Dictionary<int, ContinuationPointHistory> continuationHistory = null;
+
+            public NetDispatcherBase(Master server, Application app, Stream stream, ILogger logger)
+            {
+                this.app = app;
+                this.logger = logger;
+                this.server = server;
+                this.stream = stream;
+                this.maximumMessageSize = server.MaximumMessageSize;
+
+                this.UAStatusCode = (uint)StatusCode.Good;
+
+                availableContinuationPoints = new Stack<int>();
+                for (int i = MaxContinuationPoints - 1; i >= 0; i--)
+                {
+                    availableContinuationPoints.Push(1 + i);
+                }
+                continuationBrowse = new Dictionary<int, ContinuationPointBrowse>();
+                continuationHistory = new Dictionary<int, ContinuationPointHistory>();
+
+                pendingNotificationRequests = new Queue<RequestHeader>();
+                pendingSubscriptionAcknowledgements = new Dictionary<uint, Queue<uint>>();
+                //monitorMap = new Dictionary<uint, Application.MonitorDispatcherConfiguration>();
+                //monitorList = new List<Application.MonitorDispatcherConfiguration>();
+
+                subscriptionMap = new Dictionary<uint, Subscription>();
+
+                thread = new Thread(new ParameterizedThreadStart(ThreadTarget));
+                thread.Name = $"Client Thread {(stream as NetworkStream).Socket.RemoteEndPoint}";
+            }
+
+            protected static void ThreadTarget(object args)
+            {
+                (args as NetDispatcherBase).ThreadTarget();
+            }
+
+            // Skip MessageType and ChunkType, write MessageSize
+            protected void MarkPositionAsSize(MemoryBuffer mb)
+            {
+                UInt32 pos = (UInt32)mb.Position;
+                mb.Position = 4;
+                mb.Encode(pos);
+                mb.Position = (int)pos;
+            }
+
+            protected void MarkPositionAsSize(MemoryBuffer mb, UInt32 position)
+            {
+                int restorePos = mb.Position;
+                mb.Position = 4;
+                mb.Encode(position);
+                mb.Position = restorePos;
+            }
+
+            private void TLError(uint statusCode)
+            {
+                using var respBuf = new MemoryBuffer(1 << 10);
+                bool succeeded = true;
+                succeeded &= respBuf.Encode((uint)(MessageType.Error) | ((uint)'F' << 24));
+                succeeded &= respBuf.Encode((UInt32)0);
+                succeeded &= respBuf.Encode((UInt32)statusCode);
+                succeeded &= respBuf.EncodeUAString(string.Format("TL error 0x{0}", statusCode.ToString("X")));
+
+                if (succeeded)
+                {
+                    MarkPositionAsSize(respBuf);
+
+                    try
+                    {
+                        stream.Write(respBuf.Buffer, 0, respBuf.Position);
+                    }
+                    catch (SocketException ex)
+                    {
+                        logger?.Log(LogLevel.Error, string.Format("Socket error {1} for TL error 0x{0}", statusCode.ToString("X"), ex.Message));
+                    }
+                }
+
+                logger?.Log(LogLevel.Error, string.Format("Sent TL error 0x{0}", statusCode.ToString("X")));
+            }
+
+            private void ThreadTarget()
+            {
+                var sessionInfo = new Application.SessionCreationInfo()
+                {
+                    Endpoint = (stream as NetworkStream)?.Socket?.RemoteEndPoint
+                };
+
+                logger?.Log(LogLevel.Information, string.Format("Accepted connection from {0}", sessionInfo.Endpoint));
+
+                config = new SLChannel
+                {
+                    Endpoint = sessionInfo.Endpoint as IPEndPoint,
+                    Session = app.SessionCreate(sessionInfo),
+                    SLState = ConnectionState.Opening
+                };
+
+                int recvAccumSize = 0;
+                var recvBuffer = new byte[maximumMessageSize];
+                while (stream != null)
+                {
+                    if (threadAbort)
+                    {
+                        break;
+                    }
+
+                    while (NeedsPulse())
+                    {
+                        Monitor.Enter(csDispatching);
+
+                        try
+                        {
+                            //var sw = new System.Diagnostics.Stopwatch();
+                            //sw.Start();
+                            if (!Pulse())
+                            {
+                                logger?.Log(LogLevel.Error, "Pulse failed");
+                                recvAccumSize = -1;
+                                break;
+                            }
+                            //sw.Stop();
+                            //Console.WriteLine("Pulse in {0}", sw.Elapsed.ToString());
+                        }
+                        finally
+                        {
+                            Monitor.Exit(csDispatching);
+                        }
+                    }
+
+                    try
+                    {
+                        if (!(stream as NetworkStream).DataAvailable)
+                        {
+                            continue;
+                        }
+                    }
+                    catch (SocketException)
+                    {
+                        // Disconnected
+                        break;
+                    }
+
+                    int bytesAvailable = maximumMessageSize - recvAccumSize;
+                    if (bytesAvailable < 0)
+                    {
+                        break;
+                    }
+
+
+                    int bytesRead;
+                    try
+                    {
+                        bytesRead = stream.Read(recvBuffer, recvAccumSize, bytesAvailable);
+                    }
+                    catch
+                    {
+                        break;
+                    }
+
+                    if (bytesRead == 0)
+                    {
+                        // Disconnected
+                        break;
+                    }
+
+                    recvAccumSize += bytesRead;
+                    if (recvAccumSize > maximumMessageSize)
+                    {
+                        logger?.Log(LogLevel.Error, string.Format("Received {0} but maximum message size is {1}", recvAccumSize, maximumMessageSize));
+                        break;
+                    }
+
+                    while (recvAccumSize > 0 && UAStatusCode == (uint)StatusCode.Good)
+                    {
+                        Monitor.Enter(csDispatching);
+                        int consumedSize = -1;
+
+                        try
+                        {
+                            consumedSize = Consume(new MemoryBuffer(recvBuffer, recvAccumSize));
+                        }
+                        catch (NotImplementedException)
+                        {
+                            if (UAStatusCode == (uint)StatusCode.Good) { UAStatusCode = (uint)StatusCode.BadNotImplemented; }
+                            consumedSize = ErrorInternal;
+                        }
+                        catch
+                        {
+                            consumedSize = ErrorInternal;
+                        }
+                        finally
+                        {
+                            Monitor.Exit(csDispatching);
+                        }
+
+                        if (consumedSize < 0)
+                        {
+                            if (UAStatusCode == (uint)StatusCode.Good)
+                            {
+                                if (consumedSize == ErrorInternal) { UAStatusCode = (uint)StatusCode.BadInternalError; }
+                                if (consumedSize == ErrorParseFail) { UAStatusCode = (uint)StatusCode.BadDecodingError; }
+                                if (consumedSize == ErrorRespWrite) { UAStatusCode = (uint)StatusCode.BadEncodingLimitsExceeded; }
+                            }
+
+                            // Handler failed
+                            recvAccumSize = -1;
+                            break;
+                        }
+                        else if (consumedSize == 0)
+                        {
+                            // Not enough to read a message
+                            break;
+                        }
+                        else if (consumedSize >= recvAccumSize)
+                        {
+                            if (consumedSize > recvAccumSize)
+                            {
+                                logger?.Log(LogLevel.Error, string.Format("Consumed {0} but accumulated message size is {1}", consumedSize, recvAccumSize));
+                            }
+
+                            recvAccumSize = 0;
+                        }
+                        else
+                        {
+                            int newSize = recvAccumSize - consumedSize;
+
+                            var newRecvBuffer = new byte[maximumMessageSize];
+                            Array.Copy(recvBuffer, consumedSize, newRecvBuffer, 0, newSize);
+                            recvBuffer = newRecvBuffer;
+
+                            recvAccumSize = newSize;
+                        }
+
+                        if (UAStatusCode != (uint)StatusCode.Good)
+                        {
+                            threadAbort = true;
+                        }
+                    }
+
+                    // Cannot receive more or process existing
+                    if (recvAccumSize >= maximumMessageSize)
+                    {
+                        logger?.Log(LogLevel.Error, string.Format("Received {0} but maximum message size is {1}", recvAccumSize, maximumMessageSize));
+                        break;
+                    }
+
+                    if (recvAccumSize < 0)
+                    {
+                        break;
+                    }
+                }
+
+                if (UAStatusCode != (uint)StatusCode.Good)
+                {
+                    TLError(UAStatusCode);
+                }
+
+                if (config.Session != null)
+                {
+                    app.SessionRelease(config.Session);
+                }
+
+                try
+                {
+                    (stream as NetworkStream)?.Socket?.Shutdown(SocketShutdown.Send);
+                    stream.Close();
+                }
+                catch (SocketException)
+                {
+                    // Disconnected
+                }
+
+                server.RemoveDispatcher(this);
+
+                //foreach (var cfg in monitorMap.Values)
+                //{
+                //	app.MonitorDispatcherRemove(cfg);
+                //}
+
+                logger?.Log(LogLevel.Information, string.Format("Ended connection from {0}", sessionInfo.Endpoint));
+            }
+
+            virtual protected bool NeedsPulse()
+            {
+                return false;
+            }
+
+            virtual protected bool Pulse()
+            {
+                return false;
+            }
+
+            virtual protected int Consume(MemoryBuffer recvBuf)
+            {
+                return -1;
+            }
+
+            public void Close()
+            {
+                if (thread != null)
+                {
+                    threadAbort = true;
+
+                    thread.Join();
+                    thread = null;
+                }
+
+                server.RemoveDispatcher(this);
+            }
+        }
+    }
+}

--- a/NET Core/LibUA/Server.cs
+++ b/NET Core/LibUA/Server.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 using LibUA.Core;
 using Microsoft.Extensions.Logging;
 
@@ -17,11 +17,8 @@ namespace LibUA
 
             protected int Port, Timeout, Backlog, MaxClients;
             protected ILogger logger = null;
-            private Socket listener = null;
+            private TcpListener listener = null;
             private Thread listenerThread = null;
-            private ManualResetEvent listenerAccepted = null;
-            private ManualResetEvent listenerAbort = null;
-            private Semaphore listenerAvailable = null;
             private readonly List<NetDispatcherBase> dispatchers = null;
             private readonly object dispatchersLock = new object();
 
@@ -51,30 +48,21 @@ namespace LibUA
                     Stop();
                 }
 
-                listenerAccepted = new ManualResetEvent(false);
-                listenerAbort = new ManualResetEvent(false);
-                listenerAvailable = new Semaphore(MaxClients, MaxClients);
-
                 IPEndPoint localEndPoint = new IPEndPoint(LocalEndpoint, Port);
 
-                listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                listener.Bind(localEndPoint);
-                listener.Listen(Backlog);
+                listener = new TcpListener(localEndPoint);
+                listener.Start(Backlog);
 
                 listenerThread = new Thread(new ParameterizedThreadStart(ListenerThreadTarget));
+                listenerThread.Name = $"Listener Thread : {localEndPoint}";
                 listenerThread.Start(this);
             }
 
             public void Stop()
             {
-                if (listener != null)
-                {
-                    listenerAbort.Set();
-                    listenerAccepted.Set();
-
-                    listener.Dispose();
-                    listener = null;
-                }
+                listener?.Stop();
+                listener?.Dispose();
+                listener = null;
 
                 listenerThread?.Join();
 
@@ -87,86 +75,35 @@ namespace LibUA
                 dispatchers.Clear();
             }
 
-            protected static void ListenerThreadTarget(object args)
+            protected static async void ListenerThreadTarget(object args)
             {
-                (args as Master).ListenerThreadTarget();
+                await (args as Master).ListenerThreadTarget();
             }
 
-            protected void ListenerThreadTarget()
+            protected async Task ListenerThreadTarget()
             {
-                while (!listenerAbort.WaitOne(0))
+                while(true)
                 {
-                    if (!listenerAvailable.WaitOne(100))
+                    var client = await listener.AcceptSocketAsync(cancellationToken: default);
+                    if(dispatchers.Count >= MaxClients)
                     {
+                        client?.Close();
                         continue;
                     }
-
-                    listenerAccepted.Reset();
-                    listener.BeginAccept(new AsyncCallback(AcceptCallback), this);
-                    listenerAccepted.WaitOne();
-                }
-            }
-
-            protected static void AcceptCallback(IAsyncResult ar)
-            {
-                (ar.AsyncState as Master).Accept(ar);
-            }
-
-            protected void Accept(IAsyncResult ar)
-            {
-                if (listener == null)
-                {
-                    return;
-                }
-
-                try
-                {
-                    var handler = listener.EndAccept(ar);
-
-                    if (handler != null)
+                    client.NoDelay = true;
+                    var clientStream = new NetworkStream(client, true);
+                    lock (dispatchersLock)
                     {
-                        handler.NoDelay = true;
-
-                        Monitor.Enter(dispatchersLock);
-                        try
-                        {
-                            dispatchers.Add(new NetDispatcher(this, App, handler, logger));
-                        }
-                        finally
-                        {
-                            Monitor.Exit(dispatchersLock);
-                        }
-                    }
-                    else
-                    {
-                        listenerAvailable.Release();
+                        dispatchers.Add(new NetDispatcher(this, App, clientStream, logger));
                     }
 
-                    listenerAccepted.Set();
-                }
-                catch
-                {
-                    // Listener closed
-
-                    listenerAvailable.Release();
-                    listenerAccepted.Set();
                 }
             }
-
             internal void RemoveDispatcher(NetDispatcherBase netDispatcher)
             {
-                Monitor.Enter(dispatchersLock);
-                try
+                lock(dispatchersLock)
                 {
-                    if (dispatchers.Contains(netDispatcher))
-                    {
-                        dispatchers.Remove(netDispatcher);
-                        listenerAvailable.Release();
-                    }
-                }
-                finally
-                {
-                    Monitor.Exit(dispatchersLock);
+                    dispatchers.Remove(netDispatcher);
                 }
             }
         }
@@ -202,368 +139,6 @@ namespace LibUA
 
                 IsValid = false;
                 Offset = 0;
-            }
-        }
-
-        public class NetDispatcherBase
-        {
-            public const int MaxContinuationPoints = 256;
-            public const int MaxPublishRequests = 1024;
-            public const int MaxMonitoredPerSubscription = 65536;
-            public const int MaxTokenLifetime = 600 * 1000;
-            public const uint MaxBrowseResults = 10000;
-            public const uint MaxHistoryReadNodes = 256;
-            public const uint MaxSubscriptionAcknowledgementsPerPublish = 16;
-
-            // Message type, message size, secure channel ID, security token ID
-            public const int MessageEncodedBlockStart = 16;
-            public const int ChunkHeaderOverhead = 4 * 6;
-
-            public const double UsableMessageSizeFactor = 0.8;
-            public const int TLPaddingOverhead = 1024;
-            private uint uaStatusCode = 0;
-            public uint UAStatusCode
-            {
-                get { return uaStatusCode; }
-                protected set { uaStatusCode = value; }
-            }
-
-            protected const int ErrorInternal = -1;
-            protected const int ErrorParseFail = -2;
-            protected const int ErrorRespWrite = -3;
-            protected const int ErrorClosed = -4;
-
-            public const int PulseInterval = 100;
-
-            protected Application app = null;
-            protected ILogger logger = null;
-            private readonly Master server = null;
-            protected Socket socket = null;
-            protected int maximumMessageSize;
-
-            // Ensure publishes are in sequence and not in parallel
-            private readonly object csDispatching = new object();
-
-            protected Thread thread = null;
-            protected bool threadAbort = false;
-
-            protected SLChannel config = null;
-
-            protected UInt32 nextSubscriptionID = 1;
-            protected Queue<RequestHeader> pendingNotificationRequests = null;
-            protected Dictionary<uint, Queue<uint>> pendingSubscriptionAcknowledgements = null;
-            //protected Dictionary<uint, Application.MonitorDispatcherConfiguration> monitorMap = null;
-            //protected List<Application.MonitorDispatcherConfiguration> monitorList = null;
-
-            protected Dictionary<UInt32, Subscription> subscriptionMap = null;
-
-            protected Stack<int> availableContinuationPoints = null;
-            protected Dictionary<int, ContinuationPointBrowse> continuationBrowse = null;
-            protected Dictionary<int, ContinuationPointHistory> continuationHistory = null;
-
-            public NetDispatcherBase(Master server, Application app, Socket socket, ILogger logger)
-            {
-                this.app = app;
-                this.logger = logger;
-                this.server = server;
-                this.socket = socket;
-                this.maximumMessageSize = server.MaximumMessageSize;
-
-                this.UAStatusCode = (uint)StatusCode.Good;
-
-                availableContinuationPoints = new Stack<int>();
-                for (int i = MaxContinuationPoints - 1; i >= 0; i--)
-                {
-                    availableContinuationPoints.Push(1 + i);
-                }
-                continuationBrowse = new Dictionary<int, ContinuationPointBrowse>();
-                continuationHistory = new Dictionary<int, ContinuationPointHistory>();
-
-                pendingNotificationRequests = new Queue<RequestHeader>();
-                pendingSubscriptionAcknowledgements = new Dictionary<uint, Queue<uint>>();
-                //monitorMap = new Dictionary<uint, Application.MonitorDispatcherConfiguration>();
-                //monitorList = new List<Application.MonitorDispatcherConfiguration>();
-
-                subscriptionMap = new Dictionary<uint, Subscription>();
-
-                thread = new Thread(new ParameterizedThreadStart(ThreadTarget));
-            }
-
-            protected static void ThreadTarget(object args)
-            {
-                (args as NetDispatcherBase).ThreadTarget();
-            }
-
-            // Skip MessageType and ChunkType, write MessageSize
-            protected void MarkPositionAsSize(MemoryBuffer mb)
-            {
-                UInt32 pos = (UInt32)mb.Position;
-                mb.Position = 4;
-                mb.Encode(pos);
-                mb.Position = (int)pos;
-            }
-
-            protected void MarkPositionAsSize(MemoryBuffer mb, UInt32 position)
-            {
-                int restorePos = mb.Position;
-                mb.Position = 4;
-                mb.Encode(position);
-                mb.Position = restorePos;
-            }
-
-            private void TLError(uint statusCode)
-            {
-                using var respBuf = new MemoryBuffer(1 << 10);
-                bool succeeded = true;
-                succeeded &= respBuf.Encode((uint)(MessageType.Error) | ((uint)'F' << 24));
-                succeeded &= respBuf.Encode((UInt32)0);
-                succeeded &= respBuf.Encode((UInt32)statusCode);
-                succeeded &= respBuf.EncodeUAString(string.Format("TL error 0x{0}", statusCode.ToString("X")));
-
-                if (succeeded)
-                {
-                    MarkPositionAsSize(respBuf);
-
-                    try
-                    {
-                        socket.Send(respBuf.Buffer, respBuf.Position, SocketFlags.None);
-                    }
-                    catch (SocketException ex)
-                    {
-                        logger?.Log(LogLevel.Error, string.Format("Socket error {1} for TL error 0x{0}", statusCode.ToString("X"), ex.Message));
-                    }
-                }
-
-                logger?.Log(LogLevel.Error, string.Format("Sent TL error 0x{0}", statusCode.ToString("X")));
-            }
-
-            private void ThreadTarget()
-            {
-                var sessionInfo = new Application.SessionCreationInfo()
-                {
-                    Endpoint = socket.RemoteEndPoint
-                };
-
-                logger?.Log(LogLevel.Information, string.Format("Accepted connection from {0}", sessionInfo.Endpoint));
-
-                config = new SLChannel
-                {
-                    Endpoint = socket.RemoteEndPoint as IPEndPoint,
-                    Session = app.SessionCreate(sessionInfo),
-                    SLState = ConnectionState.Opening
-                };
-
-                int recvAccumSize = 0;
-                var recvBuffer = new byte[maximumMessageSize];
-                while (socket != null && socket.Connected)
-                {
-                    if (threadAbort)
-                    {
-                        break;
-                    }
-
-                    while (NeedsPulse())
-                    {
-                        Monitor.Enter(csDispatching);
-
-                        try
-                        {
-                            //var sw = new System.Diagnostics.Stopwatch();
-                            //sw.Start();
-                            if (!Pulse())
-                            {
-                                logger?.Log(LogLevel.Error, "Pulse failed");
-                                recvAccumSize = -1;
-                                break;
-                            }
-                            //sw.Stop();
-                            //Console.WriteLine("Pulse in {0}", sw.Elapsed.ToString());
-                        }
-                        finally
-                        {
-                            Monitor.Exit(csDispatching);
-                        }
-                    }
-
-                    try
-                    {
-                        if (!socket.Poll(PulseInterval * 1000, SelectMode.SelectRead))
-                        {
-                            continue;
-                        }
-                    }
-                    catch (SocketException)
-                    {
-                        // Disconnected
-                        break;
-                    }
-
-                    int bytesAvailable = maximumMessageSize - recvAccumSize;
-                    if (bytesAvailable < 0)
-                    {
-                        break;
-                    }
-
-
-                    int bytesRead;
-                    try
-                    {
-                        bytesRead = socket.Receive(recvBuffer, recvAccumSize, bytesAvailable, SocketFlags.None);
-                    }
-                    catch
-                    {
-                        break;
-                    }
-
-                    if (bytesRead == 0)
-                    {
-                        // Disconnected
-                        break;
-                    }
-
-                    recvAccumSize += bytesRead;
-                    if (recvAccumSize > maximumMessageSize)
-                    {
-                        logger?.Log(LogLevel.Error, string.Format("Received {0} but maximum message size is {1}", recvAccumSize, maximumMessageSize));
-                        break;
-                    }
-
-                    while (recvAccumSize > 0 && UAStatusCode == (uint)StatusCode.Good)
-                    {
-                        Monitor.Enter(csDispatching);
-                        int consumedSize = -1;
-
-                        try
-                        {
-                            consumedSize = Consume(new MemoryBuffer(recvBuffer, recvAccumSize));
-                        }
-                        catch (NotImplementedException)
-                        {
-                            if (UAStatusCode == (uint)StatusCode.Good) { UAStatusCode = (uint)StatusCode.BadNotImplemented; }
-                            consumedSize = ErrorInternal;
-                        }
-                        catch
-                        {
-                            consumedSize = ErrorInternal;
-                        }
-                        finally
-                        {
-                            Monitor.Exit(csDispatching);
-                        }
-
-                        if (consumedSize < 0)
-                        {
-                            if (UAStatusCode == (uint)StatusCode.Good)
-                            {
-                                if (consumedSize == ErrorInternal) { UAStatusCode = (uint)StatusCode.BadInternalError; }
-                                if (consumedSize == ErrorParseFail) { UAStatusCode = (uint)StatusCode.BadDecodingError; }
-                                if (consumedSize == ErrorRespWrite) { UAStatusCode = (uint)StatusCode.BadEncodingLimitsExceeded; }
-                            }
-
-                            // Handler failed
-                            recvAccumSize = -1;
-                            break;
-                        }
-                        else if (consumedSize == 0)
-                        {
-                            // Not enough to read a message
-                            break;
-                        }
-                        else if (consumedSize >= recvAccumSize)
-                        {
-                            if (consumedSize > recvAccumSize)
-                            {
-                                logger?.Log(LogLevel.Error, string.Format("Consumed {0} but accumulated message size is {1}", consumedSize, recvAccumSize));
-                            }
-
-                            recvAccumSize = 0;
-                        }
-                        else
-                        {
-                            int newSize = recvAccumSize - consumedSize;
-
-                            var newRecvBuffer = new byte[maximumMessageSize];
-                            Array.Copy(recvBuffer, consumedSize, newRecvBuffer, 0, newSize);
-                            recvBuffer = newRecvBuffer;
-
-                            recvAccumSize = newSize;
-                        }
-
-                        if (UAStatusCode != (uint)StatusCode.Good)
-                        {
-                            threadAbort = true;
-                        }
-                    }
-
-                    // Cannot receive more or process existing
-                    if (recvAccumSize >= maximumMessageSize)
-                    {
-                        logger?.Log(LogLevel.Error, string.Format("Received {0} but maximum message size is {1}", recvAccumSize, maximumMessageSize));
-                        break;
-                    }
-
-                    if (recvAccumSize < 0)
-                    {
-                        break;
-                    }
-                }
-
-                if (UAStatusCode != (uint)StatusCode.Good)
-                {
-                    TLError(UAStatusCode);
-                }
-
-                if (config.Session != null)
-                {
-                    app.SessionRelease(config.Session);
-                }
-
-                try
-                {
-                    socket.Shutdown(SocketShutdown.Send);
-                    socket.Close();
-                }
-                catch (SocketException)
-                {
-                    // Disconnected
-                }
-
-                server.RemoveDispatcher(this);
-
-                //foreach (var cfg in monitorMap.Values)
-                //{
-                //	app.MonitorDispatcherRemove(cfg);
-                //}
-
-                logger?.Log(LogLevel.Information, string.Format("Ended connection from {0}", sessionInfo.Endpoint));
-            }
-
-            virtual protected bool NeedsPulse()
-            {
-                return false;
-            }
-
-            virtual protected bool Pulse()
-            {
-                return false;
-            }
-
-            virtual protected int Consume(MemoryBuffer recvBuf)
-            {
-                return -1;
-            }
-
-            public void Close()
-            {
-                if (thread != null)
-                {
-                    threadAbort = true;
-
-                    thread.Join();
-                    thread = null;
-                }
-
-                server.RemoveDispatcher(this);
             }
         }
     }

--- a/NET/LibUA/LibUA.csproj
+++ b/NET/LibUA/LibUA.csproj
@@ -55,6 +55,8 @@
     <Compile Include="MemoryBuffer.cs" />
     <Compile Include="MemoryBufferExtensions.cs" />
     <Compile Include="NetDispatcher.cs" />
+    <Compile Include="NetDispatcherBase.cs" />
+    <Compile Include="NetworkStreamWithSocket.cs" />
     <Compile Include="Security.Cryptography\AesCng.cs" />
     <Compile Include="Security.Cryptography\AuthenticatedAes.cs" />
     <Compile Include="Security.Cryptography\AuthenticatedAesCng.cs" />

--- a/NET/LibUA/NetDispatcher.cs
+++ b/NET/LibUA/NetDispatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
@@ -22,8 +23,8 @@ namespace LibUA
                 return string.Format("{0}:{1}", config.Endpoint.ToString(), config.Session.ToString());
             }
 
-            public NetDispatcher(Master server, Application app, Socket socket, ILogger logger)
-                : base(server, app, socket, logger)
+            public NetDispatcher(Master server, Application app, Stream stream, ILogger logger)
+                : base(server, app, stream, logger)
             {
                 // Initialize then start consumer
                 thread.Start(this);
@@ -1298,7 +1299,7 @@ namespace LibUA
                             }
                         }
 
-                        _ = socket.Send(chunk.Buffer, chunk.Position, SocketFlags.None);
+                        stream.Write(chunk.Buffer, 0, chunk.Position);
                     }
 
                     //var chunkSizes = ChunkCalculateSizes(bigChunkBuffer);
@@ -1332,7 +1333,7 @@ namespace LibUA
                         }
                     }
 
-                    _ = socket.Send(respBuf.Buffer, respBuf.Position, SocketFlags.None);
+                    stream.Write(respBuf.Buffer, 0, respBuf.Position);
                 }
             }
 
@@ -1681,7 +1682,7 @@ namespace LibUA
 
                 config.LocalSequence.SequenceNumber++;
 
-                socket.Send(respBuf.Buffer, respBuf.Position, SocketFlags.None);
+                stream.Write(respBuf.Buffer, 0, respBuf.Position);
                 return (int)messageSize;
             }
 
@@ -1756,7 +1757,7 @@ namespace LibUA
 
                 MarkPositionAsSize(respBuf);
 
-                socket.Send(respBuf.Buffer, respBuf.Position, SocketFlags.None);
+                stream.Write(respBuf.Buffer, 0, respBuf.Position);
                 return (int)messageSize;
             }
 

--- a/NET/LibUA/NetDispatcherBase.cs
+++ b/NET/LibUA/NetDispatcherBase.cs
@@ -1,0 +1,376 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using LibUA.Core;
+
+namespace LibUA
+{
+    namespace Server
+    {
+        public class NetDispatcherBase
+        {
+            public const int MaxContinuationPoints = 256;
+            public const int MaxPublishRequests = 1024;
+            public const int MaxMonitoredPerSubscription = 65536;
+            public const int MaxTokenLifetime = 600 * 1000;
+            public const uint MaxBrowseResults = 10000;
+            public const uint MaxHistoryReadNodes = 256;
+            public const uint MaxSubscriptionAcknowledgementsPerPublish = 16;
+
+            // Message type, message size, secure channel ID, security token ID
+            public const int MessageEncodedBlockStart = 16;
+            public const int ChunkHeaderOverhead = 4 * 6;
+
+            public const double UsableMessageSizeFactor = 0.8;
+            public const int TLPaddingOverhead = 1024;
+            private uint uaStatusCode = 0;
+            public uint UAStatusCode
+            {
+                get { return uaStatusCode; }
+                protected set { uaStatusCode = value; }
+            }
+
+            protected const int ErrorInternal = -1;
+            protected const int ErrorParseFail = -2;
+            protected const int ErrorRespWrite = -3;
+            protected const int ErrorClosed = -4;
+
+            public const int PulseInterval = 100;
+
+            protected Application app = null;
+            protected ILogger logger = null;
+            private readonly Master server = null;
+            protected Stream stream = null;
+            protected int maximumMessageSize;
+
+            // Ensure publishes are in sequence and not in parallel
+            private readonly object csDispatching = new object();
+
+            protected Thread thread = null;
+            protected bool threadAbort = false;
+
+            protected SLChannel config = null;
+
+            protected UInt32 nextSubscriptionID = 1;
+            protected Queue<RequestHeader> pendingNotificationRequests = null;
+            protected Dictionary<uint, Queue<uint>> pendingSubscriptionAcknowledgements = null;
+            //protected Dictionary<uint, Application.MonitorDispatcherConfiguration> monitorMap = null;
+            //protected List<Application.MonitorDispatcherConfiguration> monitorList = null;
+
+            protected Dictionary<UInt32, Subscription> subscriptionMap = null;
+
+            protected Stack<int> availableContinuationPoints = null;
+            protected Dictionary<int, ContinuationPointBrowse> continuationBrowse = null;
+            protected Dictionary<int, ContinuationPointHistory> continuationHistory = null;
+
+            public NetDispatcherBase(Master server, Application app, Stream stream, ILogger logger)
+            {
+                this.app = app;
+                this.logger = logger;
+                this.server = server;
+                this.stream = stream;
+                this.maximumMessageSize = server.MaximumMessageSize;
+
+                this.UAStatusCode = (uint)StatusCode.Good;
+
+                availableContinuationPoints = new Stack<int>();
+                for (int i = MaxContinuationPoints - 1; i >= 0; i--)
+                {
+                    availableContinuationPoints.Push(1 + i);
+                }
+                continuationBrowse = new Dictionary<int, ContinuationPointBrowse>();
+                continuationHistory = new Dictionary<int, ContinuationPointHistory>();
+
+                pendingNotificationRequests = new Queue<RequestHeader>();
+                pendingSubscriptionAcknowledgements = new Dictionary<uint, Queue<uint>>();
+                //monitorMap = new Dictionary<uint, Application.MonitorDispatcherConfiguration>();
+                //monitorList = new List<Application.MonitorDispatcherConfiguration>();
+
+                subscriptionMap = new Dictionary<uint, Subscription>();
+
+                thread = new Thread(new ParameterizedThreadStart(ThreadTarget));
+                thread.Name = $"Client Thread {(stream as NetworkStreamWithSocket)._Socket.RemoteEndPoint}";
+            }
+
+            protected static void ThreadTarget(object args)
+            {
+                (args as NetDispatcherBase).ThreadTarget();
+            }
+
+            // Skip MessageType and ChunkType, write MessageSize
+            protected void MarkPositionAsSize(MemoryBuffer mb)
+            {
+                UInt32 pos = (UInt32)mb.Position;
+                mb.Position = 4;
+                mb.Encode(pos);
+                mb.Position = (int)pos;
+            }
+
+            protected void MarkPositionAsSize(MemoryBuffer mb, UInt32 position)
+            {
+                int restorePos = mb.Position;
+                mb.Position = 4;
+                mb.Encode(position);
+                mb.Position = restorePos;
+            }
+
+            private void TLError(uint statusCode)
+            {
+                var respBuf = new MemoryBuffer(1 << 10);
+                bool succeeded = true;
+                succeeded &= respBuf.Encode((uint)(MessageType.Error) | ((uint)'F' << 24));
+                succeeded &= respBuf.Encode((UInt32)0);
+                succeeded &= respBuf.Encode((UInt32)statusCode);
+                succeeded &= respBuf.EncodeUAString(string.Format("TL error 0x{0}", statusCode.ToString("X")));
+
+                if (succeeded)
+                {
+                    MarkPositionAsSize(respBuf);
+
+                    try
+                    {
+                        stream.Write(respBuf.Buffer, 0, respBuf.Position);
+                    }
+                    catch (SocketException ex)
+                    {
+                        logger?.Log(LogLevel.Error, string.Format("Socket error {1} for TL error 0x{0}", statusCode.ToString("X"), ex.Message));
+                    }
+                }
+
+                logger?.Log(LogLevel.Error, string.Format("Sent TL error 0x{0}", statusCode.ToString("X")));
+            }
+
+            private void ThreadTarget()
+            {
+                var sessionInfo = new Application.SessionCreationInfo()
+                {
+                    Endpoint = (stream as NetworkStreamWithSocket)._Socket?.RemoteEndPoint
+                };
+
+                logger?.Log(LogLevel.Info, string.Format("Accepted connection from {0}", sessionInfo.Endpoint));
+
+                config = new SLChannel
+                {
+                    Endpoint = sessionInfo.Endpoint as IPEndPoint,
+                    Session = app.SessionCreate(sessionInfo),
+                    SLState = ConnectionState.Opening
+                };
+
+                int recvAccumSize = 0;
+                var recvBuffer = new byte[maximumMessageSize];
+                while (stream != null)
+                {
+                    if (threadAbort)
+                    {
+                        break;
+                    }
+
+                    while (NeedsPulse())
+                    {
+                        Monitor.Enter(csDispatching);
+
+                        try
+                        {
+                            //var sw = new System.Diagnostics.Stopwatch();
+                            //sw.Start();
+                            if (!Pulse())
+                            {
+                                logger?.Log(LogLevel.Error, "Pulse failed");
+                                recvAccumSize = -1;
+                                break;
+                            }
+                            //sw.Stop();
+                            //Console.WriteLine("Pulse in {0}", sw.Elapsed.ToString());
+                        }
+                        finally
+                        {
+                            Monitor.Exit(csDispatching);
+                        }
+                    }
+
+                    try
+                    {
+                        if (!(stream as NetworkStream).DataAvailable)
+                        {
+                            continue;
+                        }
+                    }
+                    catch (SocketException)
+                    {
+                        // Disconnected
+                        break;
+                    }
+
+                    int bytesAvailable = maximumMessageSize - recvAccumSize;
+                    if (bytesAvailable < 0)
+                    {
+                        break;
+                    }
+
+
+                    int bytesRead;
+                    try
+                    {
+                        bytesRead = stream.Read(recvBuffer, recvAccumSize, bytesAvailable);
+                    }
+                    catch
+                    {
+                        break;
+                    }
+
+                    if (bytesRead == 0)
+                    {
+                        // Disconnected
+                        break;
+                    }
+
+                    recvAccumSize += bytesRead;
+                    if (recvAccumSize > maximumMessageSize)
+                    {
+                        logger?.Log(LogLevel.Error, string.Format("Received {0} but maximum message size is {1}", recvAccumSize, maximumMessageSize));
+                        break;
+                    }
+
+                    while (recvAccumSize > 0 && UAStatusCode == (uint)StatusCode.Good)
+                    {
+                        Monitor.Enter(csDispatching);
+                        int consumedSize = -1;
+
+                        try
+                        {
+                            consumedSize = Consume(new MemoryBuffer(recvBuffer, recvAccumSize));
+                        }
+                        catch (NotImplementedException)
+                        {
+                            if (UAStatusCode == (uint)StatusCode.Good) { UAStatusCode = (uint)StatusCode.BadNotImplemented; }
+                            consumedSize = ErrorInternal;
+                        }
+                        catch (Exception)
+                        {
+                            consumedSize = ErrorInternal;
+                        }
+                        finally
+                        {
+                            Monitor.Exit(csDispatching);
+                        }
+
+                        if (consumedSize < 0)
+                        {
+                            if (UAStatusCode == (uint)StatusCode.Good)
+                            {
+                                if (consumedSize == ErrorInternal) { UAStatusCode = (uint)StatusCode.BadInternalError; }
+                                if (consumedSize == ErrorParseFail) { UAStatusCode = (uint)StatusCode.BadDecodingError; }
+                                if (consumedSize == ErrorRespWrite) { UAStatusCode = (uint)StatusCode.BadEncodingLimitsExceeded; }
+                            }
+
+                            // Handler failed
+                            recvAccumSize = -1;
+                            break;
+                        }
+                        else if (consumedSize == 0)
+                        {
+                            // Not enough to read a message
+                            break;
+                        }
+                        else if (consumedSize >= recvAccumSize)
+                        {
+                            if (consumedSize > recvAccumSize)
+                            {
+                                logger?.Log(LogLevel.Error, string.Format("Consumed {0} but accumulated message size is {1}", consumedSize, recvAccumSize));
+                            }
+
+                            recvAccumSize = 0;
+                        }
+                        else
+                        {
+                            int newSize = recvAccumSize - consumedSize;
+
+                            var newRecvBuffer = new byte[maximumMessageSize];
+                            Array.Copy(recvBuffer, consumedSize, newRecvBuffer, 0, newSize);
+                            recvBuffer = newRecvBuffer;
+
+                            recvAccumSize = newSize;
+                        }
+
+                        if (UAStatusCode != (uint)StatusCode.Good)
+                        {
+                            threadAbort = true;
+                        }
+                    }
+
+                    // Cannot receive more or process existing
+                    if (recvAccumSize >= maximumMessageSize)
+                    {
+                        logger?.Log(LogLevel.Error, string.Format("Received {0} but maximum message size is {1}", recvAccumSize, maximumMessageSize));
+                        break;
+                    }
+
+                    if (recvAccumSize < 0)
+                    {
+                        break;
+                    }
+                }
+
+                if (UAStatusCode != (uint)StatusCode.Good)
+                {
+                    TLError(UAStatusCode);
+                }
+
+                if (config.Session != null)
+                {
+                    app.SessionRelease(config.Session);
+                }
+
+                try
+                {
+                    (stream as NetworkStreamWithSocket)?._Socket?.Shutdown(SocketShutdown.Send);
+                    stream.Close();
+                }
+                catch (SocketException)
+                {
+                    // Disconnected
+                }
+
+                server.RemoveDispatcher(this);
+
+                //foreach (var cfg in monitorMap.Values)
+                //{
+                //	app.MonitorDispatcherRemove(cfg);
+                //}
+
+                logger?.Log(LogLevel.Info, string.Format("Ended connection from {0}", sessionInfo.Endpoint));
+            }
+
+            virtual protected bool NeedsPulse()
+            {
+                return false;
+            }
+
+            virtual protected bool Pulse()
+            {
+                return false;
+            }
+
+            virtual protected int Consume(MemoryBuffer recvBuf)
+            {
+                return -1;
+            }
+
+            public void Close()
+            {
+                if (thread != null)
+                {
+                    threadAbort = true;
+
+                    thread.Join();
+                    thread = null;
+                }
+
+                server.RemoveDispatcher(this);
+            }
+        }
+    }
+}

--- a/NET/LibUA/NetworkStreamWithSocket.cs
+++ b/NET/LibUA/NetworkStreamWithSocket.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LibUA
+{
+    public class NetworkStreamWithSocket : NetworkStream
+    {
+        public NetworkStreamWithSocket(Socket socket) : base(socket) { }
+        public NetworkStreamWithSocket(Socket socket, bool ownsSocket) : base(socket, ownsSocket) { }
+        public NetworkStreamWithSocket(Socket socket, FileAccess access) : base(socket, access) { }
+        public NetworkStreamWithSocket(Socket socket, FileAccess access, bool ownsSocket) : base(socket, access, ownsSocket) { }
+
+        public Socket _Socket { get => base.Socket; }
+    }
+}

--- a/NET/LibUA/Server.cs
+++ b/NET/LibUA/Server.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 using LibUA.Core;
 
 namespace LibUA
@@ -16,11 +17,8 @@ namespace LibUA
 
             protected int Port, Timeout, Backlog, MaxClients;
             protected ILogger logger = null;
-            private Socket listener = null;
+            private TcpListener listener = null;
             private Thread listenerThread = null;
-            private ManualResetEvent listenerAccepted = null;
-            private ManualResetEvent listenerAbort = null;
-            private Semaphore listenerAvailable = null;
             private readonly List<NetDispatcherBase> dispatchers = null;
             private readonly object dispatchersLock = new object();
 
@@ -50,30 +48,20 @@ namespace LibUA
                     Stop();
                 }
 
-                listenerAccepted = new ManualResetEvent(false);
-                listenerAbort = new ManualResetEvent(false);
-                listenerAvailable = new Semaphore(MaxClients, MaxClients);
-
                 IPEndPoint localEndPoint = new IPEndPoint(LocalEndpoint, Port);
 
-                listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                listener.Bind(localEndPoint);
-                listener.Listen(Backlog);
+                listener = new TcpListener(localEndPoint);
+                listener.Start(Backlog);
 
                 listenerThread = new Thread(new ParameterizedThreadStart(ListenerThreadTarget));
+                listenerThread.Name = $"Listener Thread : {localEndPoint}";
                 listenerThread.Start(this);
             }
 
             public void Stop()
             {
-                if (listener != null)
-                {
-                    listenerAbort.Set();
-                    listenerAccepted.Set();
-
-                    listener.Dispose();
-                    listener = null;
-                }
+                listener?.Stop();
+                listener = null;
 
                 listenerThread?.Join();
 
@@ -86,86 +74,35 @@ namespace LibUA
                 dispatchers.Clear();
             }
 
-            protected static void ListenerThreadTarget(object args)
+            protected static async void ListenerThreadTarget(object args)
             {
-                (args as Master).ListenerThreadTarget();
+                await (args as Master).ListenerThreadTarget();
             }
 
-            protected void ListenerThreadTarget()
+            protected async Task ListenerThreadTarget()
             {
-                while (!listenerAbort.WaitOne(0))
+                while (true)
                 {
-                    if (!listenerAvailable.WaitOne(100))
+                    var client = await listener.AcceptSocketAsync();
+                    if (dispatchers.Count >= MaxClients)
                     {
+                        client?.Close();
                         continue;
                     }
-
-                    listenerAccepted.Reset();
-                    listener.BeginAccept(new AsyncCallback(AcceptCallback), this);
-                    listenerAccepted.WaitOne();
-                }
-            }
-
-            protected static void AcceptCallback(IAsyncResult ar)
-            {
-                (ar.AsyncState as Master).Accept(ar);
-            }
-
-            protected void Accept(IAsyncResult ar)
-            {
-                if (listener == null)
-                {
-                    return;
-                }
-
-                try
-                {
-                    var handler = listener.EndAccept(ar);
-
-                    if (handler != null)
+                    client.NoDelay = true;
+                    var clientStream = new NetworkStreamWithSocket(client, true);
+                    lock (dispatchersLock)
                     {
-                        handler.NoDelay = true;
-
-                        Monitor.Enter(dispatchersLock);
-                        try
-                        {
-                            dispatchers.Add(new NetDispatcher(this, App, handler, logger));
-                        }
-                        finally
-                        {
-                            Monitor.Exit(dispatchersLock);
-                        }
-                    }
-                    else
-                    {
-                        listenerAvailable.Release();
+                        dispatchers.Add(new NetDispatcher(this, App, clientStream, logger));
                     }
 
-                    listenerAccepted.Set();
-                }
-                catch
-                {
-                    // Listener closed
-
-                    listenerAvailable.Release();
-                    listenerAccepted.Set();
                 }
             }
-
             internal void RemoveDispatcher(NetDispatcherBase netDispatcher)
             {
-                Monitor.Enter(dispatchersLock);
-                try
+                lock (dispatchersLock)
                 {
-                    if (dispatchers.Contains(netDispatcher))
-                    {
-                        dispatchers.Remove(netDispatcher);
-                        listenerAvailable.Release();
-                    }
-                }
-                finally
-                {
-                    Monitor.Exit(dispatchersLock);
+                    dispatchers.Remove(netDispatcher);
                 }
             }
         }
@@ -201,368 +138,6 @@ namespace LibUA
 
                 IsValid = false;
                 Offset = 0;
-            }
-        }
-
-        public class NetDispatcherBase
-        {
-            public const int MaxContinuationPoints = 256;
-            public const int MaxPublishRequests = 1024;
-            public const int MaxMonitoredPerSubscription = 65536;
-            public const int MaxTokenLifetime = 600 * 1000;
-            public const uint MaxBrowseResults = 10000;
-            public const uint MaxHistoryReadNodes = 256;
-            public const uint MaxSubscriptionAcknowledgementsPerPublish = 16;
-
-            // Message type, message size, secure channel ID, security token ID
-            public const int MessageEncodedBlockStart = 16;
-            public const int ChunkHeaderOverhead = 4 * 6;
-
-            public const double UsableMessageSizeFactor = 0.8;
-            public const int TLPaddingOverhead = 1024;
-            private uint uaStatusCode = 0;
-            public uint UAStatusCode
-            {
-                get { return uaStatusCode; }
-                protected set { uaStatusCode = value; }
-            }
-
-            protected const int ErrorInternal = -1;
-            protected const int ErrorParseFail = -2;
-            protected const int ErrorRespWrite = -3;
-            protected const int ErrorClosed = -4;
-
-            public const int PulseInterval = 100;
-
-            protected Application app = null;
-            protected ILogger logger = null;
-            private readonly Master server = null;
-            protected Socket socket = null;
-            protected int maximumMessageSize;
-
-            // Ensure publishes are in sequence and not in parallel
-            private readonly object csDispatching = new object();
-
-            protected Thread thread = null;
-            protected bool threadAbort = false;
-
-            protected SLChannel config = null;
-
-            protected UInt32 nextSubscriptionID = 1;
-            protected Queue<RequestHeader> pendingNotificationRequests = null;
-            protected Dictionary<uint, Queue<uint>> pendingSubscriptionAcknowledgements = null;
-            //protected Dictionary<uint, Application.MonitorDispatcherConfiguration> monitorMap = null;
-            //protected List<Application.MonitorDispatcherConfiguration> monitorList = null;
-
-            protected Dictionary<UInt32, Subscription> subscriptionMap = null;
-
-            protected Stack<int> availableContinuationPoints = null;
-            protected Dictionary<int, ContinuationPointBrowse> continuationBrowse = null;
-            protected Dictionary<int, ContinuationPointHistory> continuationHistory = null;
-
-            public NetDispatcherBase(Master server, Application app, Socket socket, ILogger logger)
-            {
-                this.app = app;
-                this.logger = logger;
-                this.server = server;
-                this.socket = socket;
-                this.maximumMessageSize = server.MaximumMessageSize;
-
-                this.UAStatusCode = (uint)StatusCode.Good;
-
-                availableContinuationPoints = new Stack<int>();
-                for (int i = MaxContinuationPoints - 1; i >= 0; i--)
-                {
-                    availableContinuationPoints.Push(1 + i);
-                }
-                continuationBrowse = new Dictionary<int, ContinuationPointBrowse>();
-                continuationHistory = new Dictionary<int, ContinuationPointHistory>();
-
-                pendingNotificationRequests = new Queue<RequestHeader>();
-                pendingSubscriptionAcknowledgements = new Dictionary<uint, Queue<uint>>();
-                //monitorMap = new Dictionary<uint, Application.MonitorDispatcherConfiguration>();
-                //monitorList = new List<Application.MonitorDispatcherConfiguration>();
-
-                subscriptionMap = new Dictionary<uint, Subscription>();
-
-                thread = new Thread(new ParameterizedThreadStart(ThreadTarget));
-            }
-
-            protected static void ThreadTarget(object args)
-            {
-                (args as NetDispatcherBase).ThreadTarget();
-            }
-
-            // Skip MessageType and ChunkType, write MessageSize
-            protected void MarkPositionAsSize(MemoryBuffer mb)
-            {
-                UInt32 pos = (UInt32)mb.Position;
-                mb.Position = 4;
-                mb.Encode(pos);
-                mb.Position = (int)pos;
-            }
-
-            protected void MarkPositionAsSize(MemoryBuffer mb, UInt32 position)
-            {
-                int restorePos = mb.Position;
-                mb.Position = 4;
-                mb.Encode(position);
-                mb.Position = restorePos;
-            }
-
-            private void TLError(uint statusCode)
-            {
-                var respBuf = new MemoryBuffer(1 << 10);
-                bool succeeded = true;
-                succeeded &= respBuf.Encode((uint)(MessageType.Error) | ((uint)'F' << 24));
-                succeeded &= respBuf.Encode((UInt32)0);
-                succeeded &= respBuf.Encode((UInt32)statusCode);
-                succeeded &= respBuf.EncodeUAString(string.Format("TL error 0x{0}", statusCode.ToString("X")));
-
-                if (succeeded)
-                {
-                    MarkPositionAsSize(respBuf);
-
-                    try
-                    {
-                        socket.Send(respBuf.Buffer, respBuf.Position, SocketFlags.None);
-                    }
-                    catch (SocketException ex)
-                    {
-                        logger?.Log(LogLevel.Error, string.Format("Socket error {1} for TL error 0x{0}", statusCode.ToString("X"), ex.Message));
-                    }
-                }
-
-                logger?.Log(LogLevel.Error, string.Format("Sent TL error 0x{0}", statusCode.ToString("X")));
-            }
-
-            private void ThreadTarget()
-            {
-                var sessionInfo = new Application.SessionCreationInfo()
-                {
-                    Endpoint = socket.RemoteEndPoint
-                };
-
-                logger?.Log(LogLevel.Info, string.Format("Accepted connection from {0}", sessionInfo.Endpoint));
-
-                config = new SLChannel
-                {
-                    Endpoint = socket.RemoteEndPoint as IPEndPoint,
-                    Session = app.SessionCreate(sessionInfo),
-                    SLState = ConnectionState.Opening
-                };
-
-                int recvAccumSize = 0;
-                var recvBuffer = new byte[maximumMessageSize];
-                while (socket != null && socket.Connected)
-                {
-                    if (threadAbort)
-                    {
-                        break;
-                    }
-
-                    while (NeedsPulse())
-                    {
-                        Monitor.Enter(csDispatching);
-
-                        try
-                        {
-                            //var sw = new System.Diagnostics.Stopwatch();
-                            //sw.Start();
-                            if (!Pulse())
-                            {
-                                logger?.Log(LogLevel.Error, "Pulse failed");
-                                recvAccumSize = -1;
-                                break;
-                            }
-                            //sw.Stop();
-                            //Console.WriteLine("Pulse in {0}", sw.Elapsed.ToString());
-                        }
-                        finally
-                        {
-                            Monitor.Exit(csDispatching);
-                        }
-                    }
-
-                    try
-                    {
-                        if (!socket.Poll(PulseInterval * 1000, SelectMode.SelectRead))
-                        {
-                            continue;
-                        }
-                    }
-                    catch (SocketException)
-                    {
-                        // Disconnected
-                        break;
-                    }
-
-                    int bytesAvailable = maximumMessageSize - recvAccumSize;
-                    if (bytesAvailable < 0)
-                    {
-                        break;
-                    }
-
-
-                    int bytesRead;
-                    try
-                    {
-                        bytesRead = socket.Receive(recvBuffer, recvAccumSize, bytesAvailable, SocketFlags.None);
-                    }
-                    catch
-                    {
-                        break;
-                    }
-
-                    if (bytesRead == 0)
-                    {
-                        // Disconnected
-                        break;
-                    }
-
-                    recvAccumSize += bytesRead;
-                    if (recvAccumSize > maximumMessageSize)
-                    {
-                        logger?.Log(LogLevel.Error, string.Format("Received {0} but maximum message size is {1}", recvAccumSize, maximumMessageSize));
-                        break;
-                    }
-
-                    while (recvAccumSize > 0 && UAStatusCode == (uint)StatusCode.Good)
-                    {
-                        Monitor.Enter(csDispatching);
-                        int consumedSize = -1;
-
-                        try
-                        {
-                            consumedSize = Consume(new MemoryBuffer(recvBuffer, recvAccumSize));
-                        }
-                        catch (NotImplementedException)
-                        {
-                            if (UAStatusCode == (uint)StatusCode.Good) { UAStatusCode = (uint)StatusCode.BadNotImplemented; }
-                            consumedSize = ErrorInternal;
-                        }
-                        catch (Exception)
-                        {
-                            consumedSize = ErrorInternal;
-                        }
-                        finally
-                        {
-                            Monitor.Exit(csDispatching);
-                        }
-
-                        if (consumedSize < 0)
-                        {
-                            if (UAStatusCode == (uint)StatusCode.Good)
-                            {
-                                if (consumedSize == ErrorInternal) { UAStatusCode = (uint)StatusCode.BadInternalError; }
-                                if (consumedSize == ErrorParseFail) { UAStatusCode = (uint)StatusCode.BadDecodingError; }
-                                if (consumedSize == ErrorRespWrite) { UAStatusCode = (uint)StatusCode.BadEncodingLimitsExceeded; }
-                            }
-
-                            // Handler failed
-                            recvAccumSize = -1;
-                            break;
-                        }
-                        else if (consumedSize == 0)
-                        {
-                            // Not enough to read a message
-                            break;
-                        }
-                        else if (consumedSize >= recvAccumSize)
-                        {
-                            if (consumedSize > recvAccumSize)
-                            {
-                                logger?.Log(LogLevel.Error, string.Format("Consumed {0} but accumulated message size is {1}", consumedSize, recvAccumSize));
-                            }
-
-                            recvAccumSize = 0;
-                        }
-                        else
-                        {
-                            int newSize = recvAccumSize - consumedSize;
-
-                            var newRecvBuffer = new byte[maximumMessageSize];
-                            Array.Copy(recvBuffer, consumedSize, newRecvBuffer, 0, newSize);
-                            recvBuffer = newRecvBuffer;
-
-                            recvAccumSize = newSize;
-                        }
-
-                        if (UAStatusCode != (uint)StatusCode.Good)
-                        {
-                            threadAbort = true;
-                        }
-                    }
-
-                    // Cannot receive more or process existing
-                    if (recvAccumSize >= maximumMessageSize)
-                    {
-                        logger?.Log(LogLevel.Error, string.Format("Received {0} but maximum message size is {1}", recvAccumSize, maximumMessageSize));
-                        break;
-                    }
-
-                    if (recvAccumSize < 0)
-                    {
-                        break;
-                    }
-                }
-
-                if (UAStatusCode != (uint)StatusCode.Good)
-                {
-                    TLError(UAStatusCode);
-                }
-
-                if (config.Session != null)
-                {
-                    app.SessionRelease(config.Session);
-                }
-
-                try
-                {
-                    socket.Shutdown(SocketShutdown.Send);
-                    socket.Close();
-                }
-                catch (SocketException)
-                {
-                    // Disconnected
-                }
-
-                server.RemoveDispatcher(this);
-
-                //foreach (var cfg in monitorMap.Values)
-                //{
-                //	app.MonitorDispatcherRemove(cfg);
-                //}
-
-                logger?.Log(LogLevel.Info, string.Format("Ended connection from {0}", sessionInfo.Endpoint));
-            }
-
-            virtual protected bool NeedsPulse()
-            {
-                return false;
-            }
-
-            virtual protected bool Pulse()
-            {
-                return false;
-            }
-
-            virtual protected int Consume(MemoryBuffer recvBuf)
-            {
-                return -1;
-            }
-
-            public void Close()
-            {
-                if (thread != null)
-                {
-                    threadAbort = true;
-
-                    thread.Join();
-                    thread = null;
-                }
-
-                server.RemoveDispatcher(this);
             }
         }
     }


### PR DESCRIPTION
* Refactor NetDispatcherBase into its own file.
* Add thread names to Listener and Clients (within Server).
* Change from Sockets->Streams, which should allow for easier unit testing in the future (there are currently still a few casts to NetworkStream).