### PR TITLE
Acknowledge Message ReceiveBufferSize/SendBuffersize 'shall not be larger than what the Client requested'...

### DIFF
--- a/NET/LibUA/NetDispatcher.cs
+++ b/NET/LibUA/NetDispatcher.cs
@@ -1700,15 +1700,6 @@ namespace LibUA
                 }
 
                 config.TL = new TLConnection();
-                const uint chunkSize = (1 << 16) - 1;
-                config.TL.LocalConfig = new TLConfiguration()
-                {
-                    ProtocolVersion = 0,
-                    SendBufferSize = chunkSize,
-                    RecvBufferSize = chunkSize,
-                    MaxMessageSize = (uint)maximumMessageSize,
-                    MaxChunkCount = (uint)(maximumMessageSize + (chunkSize - 1)) / chunkSize,
-                };
 
                 config.TL.RemoteConfig = new TLConfiguration();
                 if (!recvBuf.Decode(out config.TL.RemoteConfig.ProtocolVersion)) { return ErrorParseFail; }
@@ -1717,17 +1708,24 @@ namespace LibUA
                 if (!recvBuf.Decode(out config.TL.RemoteConfig.MaxMessageSize)) { return ErrorParseFail; }
                 if (!recvBuf.Decode(out config.TL.RemoteConfig.MaxChunkCount)) { return ErrorParseFail; }
 
-                config.TL.LocalConfig.SendBufferSize = Math.Min(config.TL.LocalConfig.SendBufferSize, config.TL.RemoteConfig.RecvBufferSize);
+                const uint maxChunkSize = (1 << 16) - 1;
+                uint sendChunkSize = Math.Min(maxChunkSize, config.TL.RemoteConfig.RecvBufferSize);
+                uint recvChunkSize = Math.Min(maxChunkSize, config.TL.RemoteConfig.SendBufferSize);
+
                 if (config.TL.RemoteConfig.MaxMessageSize > 0)
                 {
-                    config.TL.LocalConfig.MaxMessageSize = Math.Min(config.TL.LocalConfig.MaxMessageSize, config.TL.RemoteConfig.MaxMessageSize);
+                    config.TL.RemoteConfig.MaxMessageSize = Math.Min(int.MaxValue, config.TL.RemoteConfig.MaxMessageSize);
+                    maximumMessageSize = Math.Min(maximumMessageSize, (int)config.TL.RemoteConfig.MaxMessageSize);
                 }
-                config.TL.RemoteConfig.MaxMessageSize = config.TL.LocalConfig.MaxMessageSize;
 
-                if (maximumMessageSize > config.TL.LocalConfig.MaxMessageSize)
+                config.TL.LocalConfig = new TLConfiguration()
                 {
-                    maximumMessageSize = (int)config.TL.LocalConfig.MaxMessageSize;
-                }
+                    ProtocolVersion = 0,
+                    SendBufferSize = sendChunkSize,
+                    RecvBufferSize = recvChunkSize,
+                    MaxMessageSize = (uint)maximumMessageSize,
+                    MaxChunkCount = (uint)(maximumMessageSize + (recvChunkSize - 1)) / recvChunkSize,
+                };
 
                 if (!recvBuf.DecodeUAString(out string endpoint)) { return ErrorParseFail; }
                 config.TL.RemoteEndpoint = endpoint;


### PR DESCRIPTION
https://reference.opcfoundation.org/Core/Part6/v104/docs/7.1.2.4

I've had issues lately trying to get a Siemens S7-1500 talking to LibUA, and it appears this is because the S7-1500 sends 8192bytes for both Send / Receive buffer sizes, and then when LibUA responds with 64kB, the PLC cancels the connection.

OPC-UA standard doesn't require Max Message Size to align between client / server, but existing code went with minimum.. so I kept this.

I'm unsure in what situation this line would have applied previously.

> config.TL.RemoteConfig.MaxMessageSize = config.TL.LocalConfig.MaxMessageSize;

OPC-UA standard allows both sides to send 0 for 'infinite message size allowed', which would typically align with 0 for maximum number of chunks also.