### PR TITLE
Hardcode ServiceLevel = 255 (to keep Siemens OPC-UA PLC Clients happy)

### DIFF
--- a/NET Core/LibUA/Application.cs
+++ b/NET Core/LibUA/Application.cs
@@ -280,6 +280,7 @@ namespace LibUA
                         }
                     },
                     { new NodeId(UAConst.Server_ServerStatus_State), (int)ServerState.Running },
+                    { new NodeId(UAConst.Server_ServiceLevel), (byte)255 },
 
                     { new NodeId(UAConst.OperationLimitsType_MaxNodesPerRead), 100 },
                     { new NodeId(UAConst.OperationLimitsType_MaxNodesPerWrite), 100 },

--- a/NET/LibUA/Application.cs
+++ b/NET/LibUA/Application.cs
@@ -290,6 +290,7 @@ namespace LibUA
                         }
                     },
                     { new NodeId(UAConst.Server_ServerStatus_State), (int)ServerState.Running },
+                    { new NodeId(UAConst.Server_ServiceLevel), (byte)255 },
 
                     { new NodeId(UAConst.OperationLimitsType_MaxNodesPerRead), 100 },
                     { new NodeId(UAConst.OperationLimitsType_MaxNodesPerWrite), 100 },


### PR DESCRIPTION
We hardcode the ServerState.Running.
We most as well hardcode ServiceLevel = 255
It can always be over-ridden by the application itself. But without returning a value for this, Siemens PLCs don't consider the server valid (OPC_UA_GetServerStatus fails).