### PR TITLE
Fix NodeId encoding formats and improve serialization

### DIFF
--- a/NET Core/LibUA.Tests/NodeId_Tests.cs
+++ b/NET Core/LibUA.Tests/NodeId_Tests.cs
@@ -114,5 +114,21 @@ namespace LibUA.Tests
         {
             Assert.NotEqual(new NodeId(2, [0, 1, 2, 3, 4], NodeIdNetType.ByteString), new NodeId(2, [0, 1, 2, 3, 5], NodeIdNetType.ByteString));
         }
+
+        [Fact]
+        public void NodeId_TryParseOpaqueBase64()
+        {
+            var n = NodeId.TryParse("ns=2;b=VEVTVHRlc3RURVNU");
+            Assert.NotNull(n);
+            Assert.Equal("ns=2;b=VEVTVHRlc3RURVNU", n.ToString());
+        }
+        [Fact]
+        public void NodeId_TryParseGuid()
+        {
+            var g = Guid.NewGuid();
+            var n = NodeId.TryParse($"ns=2;g={g}");
+            Assert.NotNull(n);
+            Assert.Equal($"ns=2;g={g}", n.ToString());
+        }
     }
 }

--- a/NET/LibUA/AddressSpace.cs
+++ b/NET/LibUA/AddressSpace.cs
@@ -66,6 +66,32 @@ namespace LibUA
 
                     return new NodeId(nsIdx, idx);
                 }
+                else if (vstrType.StartsWith("b=0x"))
+                {
+                    //Note: This encoding is not in the standard but should work
+                    //fine in combination with Base64 encoding below
+                    vstr = vstr.Substring(4);
+
+                    // Convert hex string to byte array
+                    byte[] byteArray = Enumerable.Range(0, vstr.Length / 2)
+                                               .Select(i => Convert.ToByte(vstr.Substring(i * 2, 2), 16))
+                                               .ToArray();
+
+                    return new NodeId(nsIdx, byteArray, NodeIdNetType.ByteString);
+                }
+                else if (vstrType.StartsWith("b="))
+                {
+                    //Convert from base 64 encoded string
+                    vstr = vstr.Substring(2);
+                    byte[] byteArray = Convert.FromBase64String(vstr);
+                    return new NodeId(nsIdx, byteArray, NodeIdNetType.ByteString);
+                }
+                else if (vstrType.StartsWith("g="))
+                {
+                    vstr = vstr.Substring(2);
+                    Guid guid = new Guid(vstr);
+                    return new NodeId(nsIdx, guid.ToByteArray(), NodeIdNetType.Guid);
+                }
 
                 return null;
             }
@@ -120,11 +146,12 @@ namespace LibUA
                 }
                 else if (IdType == NodeIdNetType.ByteString)
                 {
-                    return string.Format("ns={0};bs=0x{1}", NamespaceIndex, string.Join("", ByteStringIdentifier.Select(v => v.ToString("X2"))));
+                    return string.Format("ns={0};b={1}", NamespaceIndex, Convert.ToBase64String(ByteStringIdentifier));
                 }
                 else if (IdType == NodeIdNetType.Guid)
                 {
-                    return string.Format("ns={0};guid=0x{1}", NamespaceIndex, string.Join("", ByteStringIdentifier.Select(v => v.ToString("X2"))));
+                    var guid = new Guid(StringIdentifier);
+                    return string.Format("ns={0};g={1}", NamespaceIndex, guid.ToString());
                 }
 
                 return string.Format("ns={0};i={1}", NamespaceIndex, NumericIdentifier);


### PR DESCRIPTION
The standard only allows NodeId types of i, s, g and b. b is only allowed to be encoded as base64. Ref: https://reference.opcfoundation.org/Core/Part6/v105/docs/5.1.12#_Ref122646734
* Fix serialization in ToString() to follow standard. 
* Added support for b=0x and b=base64 in TryParse()
* Added support for g=GUID in TryParse()
* Added Tests for the Above.

Fixes #202
