### PR TITLE
Respect TypeId and Body already set for ExtensionObject

### DIFF
--- a/NET Core/LibUA/Types.cs
+++ b/NET Core/LibUA/Types.cs
@@ -5818,6 +5818,11 @@ namespace LibUA
 
             public bool TryEncodeByteString(int BufferCapacity)
             {
+                if (TypeId != null && Body != null)
+                {
+                    return true;
+                }
+                
                 TypeId = null;
                 if (Payload != null)
                 {


### PR DESCRIPTION
This PR adds an additional check for the ExtensionObject. It checks if the TypeId and Body is already set, because if this is the case then the Library can assume that everything is ok and the ByteString can be send as it is.