### PR TITLE
Backwards compatibility with .NET 6 and .NET 7

### DIFF
--- a/NET-Core/LibUA.Benchmarks/LibUA.Benchmarks.csproj
+++ b/NET-Core/LibUA.Benchmarks/LibUA.Benchmarks.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NET-Core/LibUA.Tests/LibUA.Tests.csproj
+++ b/NET-Core/LibUA.Tests/LibUA.Tests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NET-Core/LibUA/LibUA.csproj
+++ b/NET-Core/LibUA/LibUA.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageId>nauful-$(AssemblyName)-core</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/nauful/libua</PackageProjectUrl>
@@ -13,6 +13,7 @@
     <Version>1.0.33</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/NET-Core/TestClient/TestClient.csproj
+++ b/NET-Core/TestClient/TestClient.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NET-Core/TestServer/TestServer.csproj
+++ b/NET-Core/TestServer/TestServer.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Summary**
This PR adds multi-targeting support to include .NET 6.0 alongside the existing .NET 8.0 configuration.

**Motivation**
Our team is integrating this library into a project that currently targets .NET 6. To ensure compatibility, I’ve updated the .csproj files to use the TargetFrameworks property. Since the project already uses SDK-style projects, this change is straightforward and non-breaking.

**Changes Made**
Updated .csproj files to target net6.0, net7.0 and net8.0, added latest language version for compatibility.

**Impact**
This change broadens the usability of the library without affecting existing consumers on .NET 8.