### PR TITLE
Fixed decoding for types: Range and DateTime/StatusCode-arrays

### DIFF
--- a/NET-Core/LibUA/Coding.cs
+++ b/NET-Core/LibUA/Coding.cs
@@ -115,10 +115,13 @@ public class Coding
         if (type == VariantType.UInt64) { return typeof(UInt64); }
         if (type == VariantType.Float) { return typeof(float); }
         if (type == VariantType.Double) { return typeof(Double); }
+        if (type == VariantType.String) { return typeof(String); }
+        if (type == VariantType.ByteString) { return typeof(byte[]); }
         if (type == VariantType.NodeId) { return typeof(NodeId); }
         if (type == VariantType.QualifiedName) { return typeof(QualifiedName); }
         if (type == VariantType.LocalizedText) { return typeof(LocalizedText); }
-        if (type == VariantType.String) { return typeof(String); }
+        if (type == VariantType.DateTime) { return typeof(DateTime); }
+        if (type == VariantType.StatusCode) { return typeof(StatusCode); }
         if (type == VariantType.ExtensionObject) { return typeof(ExtensionObject); }
 
         // TODO: Other types

--- a/NET-Core/LibUA/Types.cs
+++ b/NET-Core/LibUA/Types.cs
@@ -5866,7 +5866,7 @@ namespace LibUA
                                 if (!buffer.Encode(eui)) { return false; }
                                 break;
                             case OpcRange range:
-                                payloadType = UAConst.Range;
+                                payloadType = UAConst.Range_Encoding_DefaultBinary;
                                 if (!buffer.Encode(range)) { return false; }
                                 break;
                             default:
@@ -5937,7 +5937,7 @@ namespace LibUA
                         if (!tmp.Decode(out eui)) { return false; }
                         Payload = eui;
                         break;
-                    case (uint)UAConst.Range:
+                    case (uint)UAConst.Range_Encoding_DefaultBinary:
                         OpcRange range;
                         if (!tmp.Decode(out range)) { return false; }
                         Payload = range;


### PR DESCRIPTION
This pull request corrects the decoding logic for two specific data types:

- OpcRange
- Arrays of DateTime and StatusCode

The cause for the array decoding issue was an missing .NET type mapping in the GetNetType() Method.
The problem with OpcRange was caused by a wrong internal ID that was used in the type-selection switch that decodes byte-string payloads.

It would be fantastic if a new NuGet package could be published once this lands. Thank you!