### PR TITLE
Use revised lifetime timeout and fix unit time

### DIFF
--- a/NET-Core/LibUA/Client.cs
+++ b/NET-Core/LibUA/Client.cs
@@ -193,7 +193,7 @@ namespace LibUA
                 UInt32 securityTokenRequestType = (uint)requestType;
                 UInt32 messageSecurityMode = (uint)config.MessageSecurityMode;
                 byte[] clientNonce = null;
-                UInt32 reqLifetime = 30 * 10000;
+                UInt32 reqLifetime = 30 * 1000;
 
                 if (config.SecurityPolicy != SecurityPolicy.None)
                 {
@@ -1888,7 +1888,7 @@ namespace LibUA
                 {
                     succeeded &= sendBuf.EncodeUAByteString(ApplicationCertificate.Export(X509ContentType.Cert));
                 }
-                succeeded &= sendBuf.Encode((Double)(10000 * requestedSessionTimeout));
+                succeeded &= sendBuf.Encode((Double)(1000 * requestedSessionTimeout));
                 succeeded &= sendBuf.Encode((UInt32)MaximumMessageSize);
 
                 if (!succeeded)
@@ -1940,15 +1940,14 @@ namespace LibUA
                 succeeded &= recvHandler.RecvBuf.Decode(out NodeId sessionIdToken);
                 succeeded &= recvHandler.RecvBuf.Decode(out NodeId authToken);
                 succeeded &= recvHandler.RecvBuf.Decode(out double revisedSessionTimeout);
-                uint revisedLifetimeMs = (uint)(revisedSessionTimeout);
                 
-                config.TokenLifetime = revisedLifetimeMs;
+                config.TokenLifetime = revisedSessionTimeout;
                 
                 if (renewTimer != null)
                 {
                     renewTimer.Stop();
                     renewTimer.Interval = 0.7 * config.TokenLifetime;
-                    renewTimer.Start(); 
+                    renewTimer.Start();
                 }
 
                 config.SessionIdToken = sessionIdToken;

--- a/NET-Core/LibUA/LibUA.csproj
+++ b/NET-Core/LibUA/LibUA.csproj
@@ -10,7 +10,7 @@
     <Title>LibUA Core</Title>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/nauful/libua</RepositoryUrl>
-    <Version>1.0.38</Version>
+    <Version>1.0.37</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <LangVersion>latest</LangVersion>

--- a/NET-Core/LibUA/Types.cs
+++ b/NET-Core/LibUA/Types.cs
@@ -7059,7 +7059,7 @@ namespace LibUA
 
             public uint ChannelID { get; set; }
             public uint TokenID { get; set; }
-            public UInt32 TokenLifetime { get; set; }
+            public double TokenLifetime { get; set; }
             public DateTimeOffset TokenCreatedAt { get; set; }
 
             public uint? PrevChannelID { get; set; }

--- a/NET/LibUA/Client.cs
+++ b/NET/LibUA/Client.cs
@@ -185,7 +185,7 @@ namespace LibUA
                 UInt32 securityTokenRequestType = (uint)requestType;
                 UInt32 messageSecurityMode = (uint)config.MessageSecurityMode;
                 byte[] clientNonce = null;
-                UInt32 reqLifetime = 30 * 10000;
+                UInt32 reqLifetime = 30 * 1000;
 
                 if (config.SecurityPolicy != SecurityPolicy.None)
                 {
@@ -1707,6 +1707,7 @@ namespace LibUA
                 {
                     return StatusCode.BadDecodingError;
                 }
+                
 
                 renewTimer?.Stop();
 
@@ -1768,7 +1769,7 @@ namespace LibUA
                 {
                     succeeded &= sendBuf.EncodeUAByteString(ApplicationCertificate.Export(X509ContentType.Cert));
                 }
-                succeeded &= sendBuf.Encode((Double)(10000 * requestedSessionTimeout));
+                succeeded &= sendBuf.Encode((Double)(1000 * requestedSessionTimeout));
                 succeeded &= sendBuf.Encode((UInt32)MaximumMessageSize);
 
                 if (!succeeded)
@@ -1821,6 +1822,15 @@ namespace LibUA
                 succeeded &= recvHandler.RecvBuf.Decode(out NodeId authToken);
                 succeeded &= recvHandler.RecvBuf.Decode(out double revisedSessionTimeout);
 
+                config.TokenLifetime = revisedSessionTimeout;
+                
+                if (renewTimer != null)
+                {
+                    renewTimer.Stop();
+                    renewTimer.Interval = 0.7 * config.TokenLifetime;
+                    renewTimer.Start();
+                }
+                
                 config.SessionIdToken = sessionIdToken;
                 config.AuthToken = authToken;
 

--- a/NET/LibUA/Types.cs
+++ b/NET/LibUA/Types.cs
@@ -6887,7 +6887,7 @@ namespace LibUA
 
             public uint ChannelID { get; set; }
             public uint TokenID { get; set; }
-            public UInt32 TokenLifetime { get; set; }
+            public double TokenLifetime { get; set; }
             public DateTimeOffset TokenCreatedAt { get; set; }
 
             public uint? PrevChannelID { get; set; }


### PR DESCRIPTION
Implements proper handling of the revised session timeout returned by the server during session creation and fixes a time unit conversion error that incorrectly converted seconds to milliseconds.

Use server-revised session timeout: The client now uses the revisedSessionTimeout from the CreateSessionResponse instead of using only the requested timeout. This follows OPC UA.
Dynamic token renewal timer: The renewal timer interval is set to 70% of the revised lifetime when the session is created.
Type update: TokenLifetime type changed from UInt32 to double to match the OPC UA revisedSessionTimeout type.

Fixed time unit conversion: Corrected conversion from 10000 to 1000 (1000 ms = 1 second) in:
Secure channel requested lifetime: 30 * 10000 → 30 * 1000 (30 seconds)
Session timeout encoding: 10000 * requestedSessionTimeout → 1000 * SessionTimeout