### PR TITLE
Fix VariantDecode: terminate Null case so it doesn't fall through to Boolean

### DIFF
--- a/NET-Core/LibUA/MemoryBuffer.cs
+++ b/NET-Core/LibUA/MemoryBuffer.cs
@@ -733,7 +733,7 @@ namespace LibUA
 
                 switch (mask & 0x3F)
                 {
-                    case (int)VariantType.Null:
+                    case (int)VariantType.Null: obj = null; return true;
                     case (int)VariantType.Boolean: { if (!Decode(out bool v)) { return false; } obj = v; return true; ; }
                     case (int)VariantType.SByte: { if (!Decode(out sbyte v)) { return false; } obj = v; return true; ; }
                     case (int)VariantType.Byte: { if (!Decode(out byte v)) { return false; } obj = v; return true; ; }

--- a/NET/LibUA/MemoryBuffer.cs
+++ b/NET/LibUA/MemoryBuffer.cs
@@ -733,7 +733,7 @@ namespace LibUA
 
                 switch (mask & 0x3F)
                 {
-                    case (int)VariantType.Null:
+                    case (int)VariantType.Null: obj = null; return true;
                     case (int)VariantType.Boolean: { if (!Decode(out bool v)) { return false; } obj = v; return true; ; }
                     case (int)VariantType.SByte: { if (!Decode(out sbyte v)) { return false; } obj = v; return true; ; }
                     case (int)VariantType.Byte: { if (!Decode(out byte v)) { return false; } obj = v; return true; ; }


### PR DESCRIPTION
## The bug

`VariantEncode` writes ZERO bytes for `VariantType.Null` (line 699:
`case (int)VariantType.Null: return true;`). But `VariantDecode`'s
switch statement lets Null fall through into the Boolean case,
which reads a bool byte and returns `false` — advancing the cursor
by one byte and corrupting every field encoded after a Null in the
same variant sequence.

Event payloads have many Null fields by spec (e.g. the
`ConditionType` fields on a `BaseEventType` refresh marker are Null
until a real condition is raised), so the current decoder makes
OPC UA Events and Conditions come through as all-false in
downstream code.

Both the `NET/LibUA/` (net48) and `NET-Core/LibUA/` (net8/net9,
which is the tree that publishes as `nauful-LibUA-core` on nuget)
have the identical bug. This PR includes matching hunks against
both trees.

## The fix

Mirror the encoder side: read zero bytes for Null, set `obj = null`,
and return true.

```diff
+                    case (int)VariantType.Null: obj = null; return true;
                     case (int)VariantType.Boolean: { ... }
```

## Origin

Carrying this locally for an OPC UA-based industrial data-
integration platform where the OpcUaCondition source was
surfacing all-false conditions in OPC UA A&E event streams. In
production across several customer sites for ~14 months.

## Companion

Second longstanding fix filed as PR #255 (EventFilter
`ExtensionObject` body-size compute-before-rewrite) — independent
but complementary; both together let downstream consumers of
`nauful-LibUA-core` drop their vendored forks.