### PR TITLE
Fix EventFilter: compute actual ExtensionObject body length before writing size placeholder

### DIFF
--- a/NET-Core/LibUA/MemoryBufferExtensions.cs
+++ b/NET-Core/LibUA/MemoryBufferExtensions.cs
@@ -981,6 +981,8 @@ namespace LibUA
             if (includeType)
             {
                 var posRestore = mem.Position;
+                // Compute actual EO body length before rewriting size placeholder.
+                eoFilterSize = (System.UInt32)(posRestore - eoFilterPos - 4);
                 mem.Position = eoFilterPos;
                 if (!mem.Encode(eoFilterSize))
                 {

--- a/NET/LibUA/MemoryBufferExtensions.cs
+++ b/NET/LibUA/MemoryBufferExtensions.cs
@@ -543,6 +543,12 @@ namespace LibUA
             if (includeType)
             {
                 var posRestore = mem.Position;
+                // Compute actual ExtensionObject body length before writing the size
+                // placeholder at eoFilterPos. Previously eoFilterSize stayed at 0
+                // through the whole path, so the EventFilter went out the wire with
+                // a zero-length ExtensionObject body header followed by the real
+                // body bytes.
+                eoFilterSize = (System.UInt32)(posRestore - eoFilterPos - 4);
                 mem.Position = eoFilterPos;
                 if (!mem.Encode(eoFilterSize))
                 {


### PR DESCRIPTION
## The bug

`EventFilterEncode` writes a 4-byte 'size' placeholder for the
ExtensionObject body at `eoFilterPos`, then writes the body bytes,
then goes back and re-writes `eoFilterSize` at `eoFilterPos`. But
`eoFilterSize` is never updated between the placeholder-write and
the re-write — it stays at its initial value of `0`. Result: the
EventFilter goes out the wire with a zero-length ExtensionObject
body header followed by the real body bytes.

Permissive servers ignore the header and parse the trailing bytes
anyway; strict servers reject the whole `CreateMonitoredItems` call
with `BadEncodingError`. Observed strict-side rejection against a
commercial OPC UA A&E gateway when subscribing to condition events
with an EventFilter that includes `SelectClauses`.

Both `NET/LibUA/` (net48) and `NET-Core/LibUA/` (net8/net9, the
tree that publishes as `nauful-LibUA-core` on nuget) have the
identical bug. This PR includes matching hunks against both.

## The fix

Compute the actual body length (`posRestore - eoFilterPos - 4`) before
the re-write:

```diff
                 var posRestore = mem.Position;
+                eoFilterSize = (System.UInt32)(posRestore - eoFilterPos - 4);
                 mem.Position = eoFilterPos;
                 if (!mem.Encode(eoFilterSize))
```

Same four-byte size-placeholder pattern is correctly handled in
`Client.cs`; that's the template this borrows.

## Origin

Carrying this locally for an OPC UA-based industrial data-
integration platform where the OpcUaCondition source was being
rejected by strict A&E-server event subscriptions. In production
across several customer sites for ~14 months.

## Companion

Second longstanding fix filed as PR #254 (`VariantDecode` Null-case
terminator).